### PR TITLE
Added support for OPC UA external access present in Logix processors …

### DIFF
--- a/src/L5Sharp.Core/Components/Tag.cs
+++ b/src/L5Sharp.Core/Components/Tag.cs
@@ -235,6 +235,16 @@ public class Tag : LogixComponent<Tag>
     }
 
     /// <summary>
+    /// The external access option indicating the read/write access of the tag from OPC UA.
+    /// </summary>
+    /// <value>A <see cref="Core.OpcUAAccess"/> option representing read/write access of the tag from OPC UA.</value>
+    public OpcUAAccess? OpcUAAccess
+    {
+        get => GetValue<OpcUAAccess>();
+        set => SetValue(value);
+    }
+
+    /// <summary>
     /// The <see cref="ComponentClass"/> value indicating whether this component is a standard or safety type component.
     /// </summary>
     /// <value>A <see cref="Core.ComponentClass"/> option representing class of the component.</value>

--- a/src/L5Sharp.Core/Enums/OpcUAAccess.cs
+++ b/src/L5Sharp.Core/Enums/OpcUAAccess.cs
@@ -1,0 +1,29 @@
+﻿namespace L5Sharp.Core;
+
+/// <summary>
+/// An enumeration of all Logix <see cref="OpcUAAccess"/> options.
+/// <remarks>
+/// <see cref="OpcUAAccess"/> is a Logix setting that determines the ability to read from or write to a given component from OPC UA.
+/// </remarks>
+/// </summary>
+public sealed class OpcUAAccess : LogixEnum<OpcUAAccess, string>
+{
+    private OpcUAAccess(string name, string value) : base(name, value)
+    {
+    }
+
+    /// <summary>
+    /// Represents no read or write <see cref="OpcUAAccess"/>.
+    /// </summary>
+    public static readonly OpcUAAccess None = new(nameof(None), nameof(None));
+
+    /// <summary>
+    /// Represents read but not write <see cref="OpcUAAccess"/>.
+    /// </summary>
+    public static readonly OpcUAAccess ReadOnly = new(nameof(ReadOnly), "Read Only");
+
+    /// <summary>
+    /// Represents read and write <see cref="OpcUAAccess"/>.
+    /// </summary>
+    public static readonly OpcUAAccess ReadWrite = new(nameof(ReadWrite), "Read/Write");
+}

--- a/tests/L5Sharp.Tests/Enums/OpcUAAccessTests.cs
+++ b/tests/L5Sharp.Tests/Enums/OpcUAAccessTests.cs
@@ -1,0 +1,26 @@
+﻿using FluentAssertions;
+
+namespace L5Sharp.Tests.Enums
+{
+    [TestFixture]
+    public class OpcUAAccessTests
+    {
+        [Test]
+        public void None_WhenCalled_ShouldNotBeNull()
+        {
+            OpcUAAccess.None.Should().NotBeNull();
+        }
+
+        [Test]
+        public void ReadOnly_WhenCalled_ShouldNotBeNull()
+        {
+            OpcUAAccess.ReadOnly.Should().NotBeNull();
+        }
+
+        [Test]
+        public void ReadWrite_WhenCalled_ShouldNotBeNull()
+        {
+            OpcUAAccess.ReadWrite.Should().NotBeNull();
+        }
+    }
+}

--- a/tests/L5Sharp.Tests/LogixParserTests.cs
+++ b/tests/L5Sharp.Tests/LogixParserTests.cs
@@ -25,6 +25,7 @@ public class LogixParserTests
     [TestCase(typeof(Dimensions))]
     [TestCase(typeof(Radix))]
     [TestCase(typeof(ExternalAccess))]
+    [TestCase(typeof(OpcUAAccess))]
     [TestCase(typeof(DINT))]
     [TestCase(typeof(REAL))]
     [TestCase(typeof(AtomicData))]
@@ -193,6 +194,22 @@ public class LogixParserTests
         tag.TagType.Should().Be(TagType.Base);
         tag.Constant.Should().BeFalse();
         tag.ExternalAccess.Should().Be(ExternalAccess.ReadWrite);
+    }
+
+    [Test]
+    public void Parse_TagElementWithOPCUA_ShouldBeExpected()
+    {
+        const string xml =
+            @"<Tag Name=""Test"" TagType=""Base"" DataType=""DINT"" Radix=""Decimal"" Constant=""false"" ExternalAccess=""Read/Write"" OpcUAAccess=""Read/Write"" />";
+
+        var tag = xml.Parse<Tag>();
+
+        tag.Should().NotBeNull();
+        tag.Name.Should().Be("Test");
+        tag.TagType.Should().Be(TagType.Base);
+        tag.Constant.Should().BeFalse();
+        tag.ExternalAccess.Should().Be(ExternalAccess.ReadWrite);
+        tag.OpcUAAccess.Should().Be(OpcUAAccess.ReadWrite);
     }
 
     [Test]


### PR DESCRIPTION
…V36 and higher.

Rockwell added support for direct OPC UA access to the V36 and higher firmware, providing the same level of control currently as the `ExternalAccess` attribute on tags. 