### PR TITLE
Feature/37 move scope to logixelement

### DIFF
--- a/src/L5Sharp.Core/ILogixLookup.cs
+++ b/src/L5Sharp.Core/ILogixLookup.cs
@@ -4,8 +4,8 @@ using System.Collections.Generic;
 namespace L5Sharp.Core;
 
 /// <summary>
-/// An interface that defines an API for searching an L5X for <see cref="LogixObject"/>
-/// having a specified name or scope.
+/// An interface that defines an API for searching an L5X for <see cref="LogixScoped"/> objects having a specified
+/// type, name, and optioanl controller/program/routine scope.
 /// </summary>
 public interface ILogixLookup
 {
@@ -32,78 +32,182 @@ public interface ILogixLookup
     /// This includes controller, program, and routine scoped elements.
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="scope"/> is nul.</exception>
-    IEnumerable<LogixObject> Find(Scope scope);
+    IEnumerable<LogixScoped> Find(Scope scope);
 
     /// <summary>
     /// Finds all elements having the specified type and name across all scopes.
     /// </summary>
     /// <param name="scope">The component name or code number that identifies the element to find.</param>
-    /// <typeparam name="TObject">The type to find.</typeparam>
+    /// <typeparam name="TScoped">The type to find.</typeparam>
     /// <returns>
     /// A collection of all elements found in the L5X having the specified type and name.
     /// This includes controller, program, and routine scoped elements.
     /// </returns>
-    IEnumerable<TObject> Find<TObject>(Scope scope) where TObject : LogixObject;
+    IEnumerable<TScoped> Find<TScoped>(Scope scope) where TScoped : LogixScoped;
 
     /// <summary>
-    /// 
+    /// Gets the element having the specified scope path and returns it as a generic <see cref="LogixScoped"/> object.
     /// </summary>
-    /// <param name="scope"></param>
-    /// <returns></returns>
-    LogixObject Get(Scope scope);
+    /// <param name="scope">The path defining the route to the element in L5X tree. This can be
+    /// a simple <c>/Type/Name</c> path or include containing program such as <c>/Program/Type/Name</c>.
+    /// For more inforamtion see <see cref="Scope"/>.</param>
+    /// <returns>
+    /// A <see cref="LogixScoped"/> instance having the specified scope path.
+    /// If no element with the provided path is found, then this method throws a <see cref="KeyNotFoundException"/>.
+    /// </returns>
+    /// <exception cref="KeyNotFoundException"> When no element with the specified <paramref name="scope"/> was found.</exception>
+    /// <remarks>
+    /// <para>
+    /// Note that this overload requires the type to be specified as part of the scope path since there is no generic type
+    /// information provided.
+    /// </para>
+    /// <para>
+    /// <c>Get</c> methods imply you know the element at the provided path exists. If this is not the case, use one of the
+    /// <c>TryGet</c> overloads.
+    /// </para>
+    /// </remarks>
+    LogixScoped Get(Scope scope);
 
     /// <summary>
-    /// 
+    /// Gets the element having the specified scope path and returns it as the specified type.
     /// </summary>
-    /// <param name="scope"></param>
-    /// <returns></returns>
-    TObject Get<TObject>(Scope scope) where TObject : LogixObject;
+    /// <param name="scope">The path defining the route to the element in L5X tree. This can be
+    /// a simple <c>/Type/Name</c> path or include containing program such as <c>/Program/Type/Name</c>.
+    /// For more inforamtion see <see cref="Scope"/>.</param>
+    /// <typeparam name="TScoped">The element type to find and return.</typeparam>
+    /// <returns>
+    /// A <see cref="LogixScoped"/> instance of the specified type having the specified scope path.
+    /// If no element with the provided path is found, then this method throws a <see cref="KeyNotFoundException"/>.
+    /// </returns>
+    /// <exception cref="KeyNotFoundException"> When no element with the specified <paramref name="scope"/> was found.</exception>
+    /// <exception cref="InvalidCastException"> When the element can't be cast to the type specified by <see cref="TScoped"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// If no type is provided as part of the scope, then the type will be infered from <see cref="TScoped"/>.
+    /// </para>
+    /// <para>
+    /// <c>Get</c> methods imply you know the element at the provided path exists. If this is not the case, use one of the
+    /// <c>TryGet</c> overloads.
+    /// </para>
+    /// </remarks>
+    TScoped Get<TScoped>(Scope scope) where TScoped : LogixScoped;
 
     /// <summary>
-    /// 
+    /// Gets the element having the specified scope path and returns it as a generic <see cref="LogixScoped"/> object.
     /// </summary>
-    /// <param name="builder"></param>
-    /// <returns></returns>
-    LogixObject Get(Func<IScopeBuilder, Scope> builder);
+    /// <param name="builder">A fluent scope builder interface that defines the path to a particular element in the L5X.</param>
+    /// <returns>
+    /// A <see cref="LogixScoped"/> instance of the specified type having the specified scope path.
+    /// If no element with the provided path is found, then this method throws a <see cref="KeyNotFoundException"/>.
+    /// </returns>
+    /// <exception cref="KeyNotFoundException">When no element having the configured scope was found.</exception>
+    /// <remarks>
+    /// <para>
+    /// <c>Get</c> methods imply you know the element at the provided path exists. If this is not the case, use one of the
+    /// <c>TryGet</c> overloads.
+    /// </para>
+    /// </remarks>
+    LogixScoped Get(Func<IScopeBuilder, Scope> builder);
 
     /// <summary>
-    /// 
+    /// Gets the element having the specified scope path and returns it as the specified type.
     /// </summary>
-    /// <param name="builder"></param>
-    /// <returns></returns>
-    TObject Get<TObject>(Func<IScopeBuilder, Scope> builder) where TObject : LogixObject;
+    /// <param name="builder">A fluent scope builder interface that defines the path to a particular element in the L5X.</param>
+    /// <typeparam name="TScoped">The element type to find and return.</typeparam>
+    /// <returns>
+    /// A <see cref="LogixScoped"/> instance of the specified type having the specified scope path.
+    /// If no element with the provided path is found, then this method throws a <see cref="KeyNotFoundException"/>.
+    /// </returns>
+    /// <exception cref="KeyNotFoundException">When no element having the configured scope was found.</exception>
+    /// <exception cref="InvalidCastException">When the element can't be cast to the type specified by <see cref="TScoped"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// <c>Get</c> methods imply you know the element at the provided path exists. If this is not the case, use one of the
+    /// <c>TryGet</c> overloads.
+    /// </para>
+    /// </remarks>
+    TScoped Get<TScoped>(Func<IScopeBuilder, Scope> builder) where TScoped : LogixScoped;
 
     /// <summary>
-    /// 
+    /// Tries to get an element with the specified scope path and returns the result.
     /// </summary>
-    /// <param name="scope"></param>
-    /// <param name="element"></param>
-    /// <returns></returns>
-    bool TryGet(Scope scope, out LogixObject element);
+    /// <param name="scope">The path defining the route to the element in L5X tree. This can be
+    /// a simple <c>/Type/Name</c> path or include containing program such as <c>/Program/Type/Name</c>.
+    /// For more inforamtion see <see cref="Scope"/>.</param>
+    /// <param name="element">The <see cref="LogixScoped"/> object that was found if an element with the provided scope exists.
+    /// If not found, then this value will be null.</param>
+    /// <returns>
+    /// <c>true</c> if the element with the specified scope was found; otherwise, <c>false</c>.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// Note that this overload requires the type to be specified as part of the scope path since there is no generic type
+    /// information provided.
+    /// </para>
+    /// <para>
+    /// <c>TryGet</c> methods imply you don't know the element at the provided path exists, as it will check and then
+    /// return the result. This is in contrast to the <c>Get</c> overloads, which will throw an exception if not found.
+    /// </para>
+    /// </remarks>
+    bool TryGet(Scope scope, out LogixScoped element);
 
     /// <summary>
-    /// 
+    /// Tries to get an element with the specified scope path and returns the result.
     /// </summary>
-    /// <param name="scope"></param>
-    /// <param name="element"></param>
-    /// <returns></returns>
-    bool TryGet<TObject>(Scope scope, out TObject element) where TObject : LogixObject;
+    /// <param name="scope">The path defining the route to the element in L5X tree. This can be
+    /// a simple <c>/Type/Name</c> path or include containing program such as <c>/Program/Type/Name</c>.
+    /// For more inforamtion see <see cref="Scope"/>.</param>
+    /// <param name="element">The <see cref="LogixScoped"/> object of the specified typ that was found if an
+    /// element with the provided scope exists. If not found, then this value will be null.</param>
+    /// <typeparam name="TScoped">The element type to find and return.</typeparam>
+    /// <returns>
+    /// <c>true</c> if the element with the specified scope was found; otherwise, <c>false</c>.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// If no type is provided as part of the scope, then the type will be infered from <see cref="TScoped"/>.
+    /// </para>
+    /// <para>
+    /// <c>TryGet</c> methods imply you don't know the element at the provided path exists, as it will check and then
+    /// return the result. This is in contrast to the <c>Get</c> overloads, which will throw an exception if not found.
+    /// </para>
+    /// </remarks>
+    bool TryGet<TScoped>(Scope scope, out TScoped element) where TScoped : LogixScoped;
 
     /// <summary>
-    /// 
+    /// Tries to get an element with the specified scope path and returns the result.
     /// </summary>
-    /// <param name="builder"></param>
-    /// <param name="element"></param>
-    /// <returns></returns>
-    bool TryGet(Func<IScopeBuilder, Scope> builder, out LogixObject element);
+    /// <param name="builder">A fluent scope builder interface that defines the path to a particular element in the L5X.</param>
+    /// <param name="element">The <see cref="LogixScoped"/> object that was found if an element with the provided scope exists.
+    /// If not found, then this value will be null.</param>
+    /// <returns>
+    /// <c>true</c> if the element with the specified scope was found; otherwise, <c>false</c>.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// <c>TryGet</c> methods imply you don't know the element at the provided path exists, as it will check and then
+    /// return the result. This is in contrast to the <c>Get</c> overloads, which will throw an exception if not found.
+    /// </para>
+    /// </remarks>
+    bool TryGet(Func<IScopeBuilder, Scope> builder, out LogixScoped element);
 
     /// <summary>
-    /// 
+    /// Tries to get an element with the specified scope path and returns the result.
     /// </summary>
-    /// <param name="builder"></param>
-    /// <param name="element"></param>
-    /// <returns></returns>
-    bool TryGet<TObject>(Func<IScopeBuilder, Scope> builder, out TObject element) where TObject : LogixObject;
+    /// <param name="builder">A fluent scope builder interface that defines the path to a particular element in the L5X.</param>
+    /// <param name="element">The <see cref="LogixScoped"/> object of the specified typ that was found if an
+    /// element with the provided scope exists. If not found, then this value will be null.</param>
+    /// <typeparam name="TScoped">The element type to find and return.</typeparam>
+    /// <returns>
+    /// <c>true</c> if the element with the specified scope was found; otherwise, <c>false</c>.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// <c>TryGet</c> methods imply you don't know the element at the provided path exists, as it will check and then
+    /// return the result. This is in contrast to the <c>Get</c> overloads, which will throw an exception if not found.
+    /// </para>
+    /// </remarks>
+    bool TryGet<TScoped>(Func<IScopeBuilder, Scope> builder, out TScoped element) where TScoped : LogixScoped;
 
     /// <summary>
     /// Retrieves a collection of <see cref="CrossReference"/> objects that reference the specified component name.

--- a/src/L5Sharp.Core/L5Sharp.Core.csproj
+++ b/src/L5Sharp.Core/L5Sharp.Core.csproj
@@ -7,9 +7,9 @@
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
         <Title>L5Sharp</Title>
         <Authors>Timothy Nunnink</Authors>
-        <Version>4.0.0</Version>
-        <AssemblyVersion>4.0.0</AssemblyVersion>
-        <FileVersion>4.0.0.0</FileVersion>
+        <Version>4.1.0</Version>
+        <AssemblyVersion>4.1.0</AssemblyVersion>
+        <FileVersion>4.1.0.0</FileVersion>
         <Description>A library for intuitively interacting with Rockwell's L5X import/export files.</Description>
         <RepositoryUrl>https://github.com/tnunnink/L5Sharp</RepositoryUrl>
         <PackageTags>csharp allen-bradely l5x logix plc-programming rockwell-automation logix5000</PackageTags>
@@ -18,7 +18,7 @@
         <!--<PackageIcon>icon.png</PackageIcon>-->
         <RepositoryType>git</RepositoryType>
         <PackageReleaseNotes>
-            This version primarily focuses on reworking the concept of element Scope and how the Lookup/Index API works.
+            Moves Scope to LogixScoped class which Component and Code now derive from.
         </PackageReleaseNotes>
         <Copyright>Copyright (c) Timothy Nunnink 2022</Copyright>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/L5Sharp.Core/L5X.cs
+++ b/src/L5Sharp.Core/L5X.cs
@@ -86,10 +86,12 @@ public sealed class L5X : ILogixSerializable, ILogixLookup
         //Depending on the options provided, either create a logix index or logix lookup for the ILogixLooup API usage.
         if (options == L5XOptions.Index)
         {
+            //LogixIndex uses dictionaries and is super performant.
             _lookup = new LogixIndex(GetController());
         }
         else
         {
+            //LogixLookup uses XPath with is not terrible but will be slow for many lookups (mostly for tag elements).
             _lookup = new LogixLookup(GetController());
         }
     }
@@ -368,61 +370,61 @@ public sealed class L5X : ILogixSerializable, ILogixLookup
     }
 
     /// <inheritdoc />
-    public IEnumerable<LogixObject> Find(Scope scope)
+    public IEnumerable<LogixScoped> Find(Scope scope)
     {
         return _lookup.Find(scope);
     }
 
     /// <inheritdoc />
-    public IEnumerable<TObject> Find<TObject>(Scope scope) where TObject : LogixObject
+    public IEnumerable<TScoped> Find<TScoped>(Scope scope) where TScoped : LogixScoped
     {
-        return _lookup.Find<TObject>(scope);
+        return _lookup.Find<TScoped>(scope);
     }
 
     /// <inheritdoc />
-    public LogixObject Get(Scope scope)
+    public LogixScoped Get(Scope scope)
     {
         return _lookup.Get(scope);
     }
 
     /// <inheritdoc />
-    public TObject Get<TObject>(Scope scope) where TObject : LogixObject
+    public TScoped Get<TScoped>(Scope scope) where TScoped : LogixScoped
     {
-        return _lookup.Get<TObject>(scope);
+        return _lookup.Get<TScoped>(scope);
     }
 
     /// <inheritdoc />
-    public LogixObject Get(Func<IScopeBuilder, Scope> builder)
+    public LogixScoped Get(Func<IScopeBuilder, Scope> builder)
     {
         return _lookup.Get(builder);
     }
 
     /// <inheritdoc />
-    public TObject Get<TObject>(Func<IScopeBuilder, Scope> builder) where TObject : LogixObject
+    public TScoped Get<TScoped>(Func<IScopeBuilder, Scope> builder) where TScoped : LogixScoped
     {
-        return _lookup.Get<TObject>(builder);
+        return _lookup.Get<TScoped>(builder);
     }
 
     /// <inheritdoc />
-    public bool TryGet(Scope scope, out LogixObject element)
-    {
-        return _lookup.TryGet(scope, out element);
-    }
-
-    /// <inheritdoc />
-    public bool TryGet<TObject>(Scope scope, out TObject element) where TObject : LogixObject
+    public bool TryGet(Scope scope, out LogixScoped element)
     {
         return _lookup.TryGet(scope, out element);
     }
 
     /// <inheritdoc />
-    public bool TryGet(Func<IScopeBuilder, Scope> builder, out LogixObject element)
+    public bool TryGet<TScoped>(Scope scope, out TScoped element) where TScoped : LogixScoped
+    {
+        return _lookup.TryGet(scope, out element);
+    }
+
+    /// <inheritdoc />
+    public bool TryGet(Func<IScopeBuilder, Scope> builder, out LogixScoped element)
     {
         return _lookup.TryGet(builder, out element);
     }
 
     /// <inheritdoc />
-    public bool TryGet<TObject>(Func<IScopeBuilder, Scope> builder, out TObject element) where TObject : LogixObject
+    public bool TryGet<TScoped>(Func<IScopeBuilder, Scope> builder, out TScoped element) where TScoped : LogixScoped
     {
         return _lookup.TryGet(builder, out element);
     }

--- a/src/L5Sharp.Core/LogixCode.cs
+++ b/src/L5Sharp.Core/LogixCode.cs
@@ -21,7 +21,7 @@ namespace L5Sharp.Core;
 /// same number.
 /// </para>
 /// </remarks>
-public abstract class LogixCode : LogixObject
+public abstract class LogixCode : LogixScoped
 {
     /// <summary>
     /// Creates a new <see cref="LogixCode"/> instance with default values.
@@ -52,21 +52,6 @@ public abstract class LogixCode : LogixObject
         get => GetValue<int>();
         set => SetValue(value);
     }
-
-    /// <summary>
-    /// The scope idetifying where in an L5X file this element exists. This can be a globally scoped controller element,
-    /// a locally scoped program or instruction element, or neither (not attached to L5X tree).
-    /// </summary>
-    /// <value>A <see cref="Scope"/> object with information regarding the scope of the element.</value>
-    /// <remarks>
-    /// <para>
-    /// The scope of an element is determined from the ancestors of the underlying <see cref="XElement"/>.
-    /// This property is not inherent in the underlying XML (not serialized), but one that adds a lot of
-    /// value as it helps uniquely identify elements within the L5X file, especially elements such as <c>Tag</c>,
-    /// <c>Routine</c>, or <c>Rung</c>.
-    /// </para>
-    /// </remarks>
-    public Scope Scope => Scope.Of(Element);
 
     /// <summary>
     /// The parent <see cref="Core.Routine"/> component for the current <c>LogixCode</c> element.

--- a/src/L5Sharp.Core/LogixComponent.cs
+++ b/src/L5Sharp.Core/LogixComponent.cs
@@ -27,7 +27,7 @@ namespace L5Sharp.Core;
 /// See <a href="https://literature.rockwellautomation.com/idc/groups/literature/documents/rm/1756-rm084_-en-p.pdf">
 /// `Logix 5000 Controllers Import/Export`</a> for more information.
 /// </footer> 
-public abstract class LogixComponent : LogixObject
+public abstract class LogixComponent : LogixScoped
 {
     /// <inheritdoc />
     protected LogixComponent(string name) : base(name)
@@ -80,21 +80,6 @@ public abstract class LogixComponent : LogixObject
         get => GetProperty<string>();
         set => SetDescription(value);
     }
-
-    /// <summary>
-    /// The scope idetifying where in an L5X file this element exists. This can be a globally scoped controller element,
-    /// a locally scoped program or instruction element, or neither (not attached to L5X tree).
-    /// </summary>
-    /// <value>A <see cref="Scope"/> object with information regarding the scope of the element.</value>
-    /// <remarks>
-    /// <para>
-    /// The scope of an element is determined from the ancestors of the underlying <see cref="XElement"/>.
-    /// This property is not inherent in the underlying XML (not serialized), but one that adds a lot of
-    /// value as it helps uniquely identify elements within the L5X file, especially elements such as <c>Tag</c>,
-    /// <c>Routine</c>, or <c>Rung</c>.
-    /// </para>
-    /// </remarks>
-    public Scope Scope => Scope.Of(Element);
 
     /// <summary>
     /// Returns a collection of <see cref="LogixComponent"/> that this component depends on to be valid within a given

--- a/src/L5Sharp.Core/LogixIndex.cs
+++ b/src/L5Sharp.Core/LogixIndex.cs
@@ -61,43 +61,43 @@ internal class LogixIndex : ILogixLookup
         return _elements.ContainsKey(scope);
     }
 
-    public IEnumerable<LogixObject> Find(Scope scope)
+    public IEnumerable<LogixScoped> Find(Scope scope)
     {
         if (scope is null)
             throw new ArgumentNullException(nameof(scope));
 
-        var results = new List<LogixObject>();
+        var results = new List<LogixScoped>();
         var scopes = GenerateScopes(scope.Type, scope.Name);
 
         foreach (var s in scopes)
             if (_elements.TryGetValue(s, out var element))
-                results.Add(element.Deserialize<LogixObject>());
+                results.Add(element.Deserialize<LogixScoped>());
 
         return results;
     }
 
-    public IEnumerable<TObject> Find<TObject>(Scope scope) where TObject : LogixObject
+    public IEnumerable<TScoped> Find<TScoped>(Scope scope) where TScoped : LogixScoped
     {
         if (scope is null)
             throw new ArgumentNullException(nameof(scope));
 
-        var results = new List<TObject>();
-        var type = scope.Type != ScopeType.Empty ? scope.Type : ScopeType.Parse(typeof(TObject).L5XType());
+        var results = new List<TScoped>();
+        var type = scope.Type != ScopeType.Empty ? scope.Type : ScopeType.Parse(typeof(TScoped).L5XType());
         var scopes = GenerateScopes(type, scope.Name.Root);
 
         foreach (var s in scopes)
         {
             if (!_elements.TryGetValue(s, out var value)) continue;
-            var element = value.Deserialize<TObject>();
+            var element = value.Deserialize<TScoped>();
             var result = element is Tag tag ? tag.Member(scope.Name.Path) as LogixObject : element;
-            if (result is not TObject typed) continue;
+            if (result is not TScoped typed) continue;
             results.Add(typed);
         }
 
         return results;
     }
 
-    public LogixObject Get(Scope scope)
+    public LogixScoped Get(Scope scope)
     {
         if (scope is null)
             throw new ArgumentNullException(nameof(scope));
@@ -107,27 +107,27 @@ internal class LogixIndex : ILogixLookup
         if (!_elements.TryGetValue(absolute, out var value))
             throw new KeyNotFoundException($"No element with the provided scope was found: {absolute}");
 
-        var result = value.Deserialize<LogixObject>();
+        var result = value.Deserialize<LogixScoped>();
 
         return result is Tag tag ? tag[absolute.Name.Path] : result;
     }
 
-    public TObject Get<TObject>(Scope scope) where TObject : LogixObject
+    public TScoped Get<TScoped>(Scope scope) where TScoped : LogixScoped
     {
         if (scope is null)
             throw new ArgumentNullException(nameof(scope));
 
-        var absolute = GenerateAbsolute(scope, typeof(TObject));
+        var absolute = GenerateAbsolute(scope, typeof(TScoped));
 
         if (!_elements.TryGetValue(absolute, out var value))
             throw new KeyNotFoundException($"No element with the provided scope was found: {absolute}");
 
-        var result = value.Deserialize<TObject>();
+        var result = value.Deserialize<TScoped>();
 
-        return result is Tag tag ? (TObject)(LogixObject)tag[absolute.Name.Path] : result;
+        return result is Tag tag ? (TScoped)(LogixObject)tag[absolute.Name.Path] : result;
     }
 
-    public LogixObject Get(Func<IScopeBuilder, Scope> builder)
+    public LogixScoped Get(Func<IScopeBuilder, Scope> builder)
     {
         if (builder is null)
             throw new ArgumentNullException(nameof(builder));
@@ -138,12 +138,12 @@ internal class LogixIndex : ILogixLookup
         if (!_elements.TryGetValue(scope, out var value))
             throw new KeyNotFoundException($"No element with the provided scope was found: {scope}");
 
-        var element = value.Deserialize<LogixObject>();
+        var element = value.Deserialize<LogixScoped>();
 
         return element is Tag tag ? tag[scope.Name.Path] : element;
     }
 
-    public TObject Get<TObject>(Func<IScopeBuilder, Scope> builder) where TObject : LogixObject
+    public TScope Get<TScope>(Func<IScopeBuilder, Scope> builder) where TScope : LogixScoped
     {
         if (builder is null)
             throw new ArgumentNullException(nameof(builder));
@@ -154,12 +154,12 @@ internal class LogixIndex : ILogixLookup
         if (!_elements.TryGetValue(scope, out var value))
             throw new KeyNotFoundException($"No element with the provided scope was found: {scope}");
 
-        var element = value.Deserialize<TObject>();
+        var element = value.Deserialize<TScope>();
 
-        return element is Tag tag ? (TObject)(LogixObject)tag[scope.Name.Path] : element;
+        return element is Tag tag ? (TScope)(LogixObject)tag[scope.Name.Path] : element;
     }
 
-    public bool TryGet(Scope scope, out LogixObject element)
+    public bool TryGet(Scope scope, out LogixScoped element)
     {
         if (scope is null)
             throw new ArgumentNullException(nameof(scope));
@@ -172,17 +172,17 @@ internal class LogixIndex : ILogixLookup
             return false;
         }
 
-        var result = value.Deserialize<LogixObject>();
+        var result = value.Deserialize<LogixScoped>();
         var target = result is Tag tag ? tag.Member(absolute.Name.Path) : result;
         return IsNull(target, out element);
     }
 
-    public bool TryGet<TObject>(Scope scope, out TObject element) where TObject : LogixObject
+    public bool TryGet<TScoped>(Scope scope, out TScoped element) where TScoped : LogixScoped
     {
         if (scope is null)
             throw new ArgumentNullException(nameof(scope));
 
-        var absolute = GenerateAbsolute(scope, typeof(TObject));
+        var absolute = GenerateAbsolute(scope, typeof(TScoped));
 
         if (!_elements.TryGetValue(absolute, out var value))
         {
@@ -190,12 +190,12 @@ internal class LogixIndex : ILogixLookup
             return false;
         }
 
-        var result = value.Deserialize<TObject>();
+        var result = value.Deserialize<TScoped>();
         var target = result is Tag tag ? tag.Member(absolute.Name.Path)?.As<LogixObject>() : result;
-        return IsNull(target as TObject, out element);
+        return IsNull(target as TScoped, out element);
     }
 
-    public bool TryGet(Func<IScopeBuilder, Scope> builder, out LogixObject element)
+    public bool TryGet(Func<IScopeBuilder, Scope> builder, out LogixScoped element)
     {
         if (builder is null)
             throw new ArgumentNullException(nameof(builder));
@@ -209,12 +209,12 @@ internal class LogixIndex : ILogixLookup
             return false;
         }
 
-        var result = value.Deserialize<LogixObject>();
-        var target = result is Tag tag ? tag.Member(scope.Name.Path)?.As<LogixObject>() : result;
+        var result = value.Deserialize<LogixScoped>();
+        var target = result is Tag tag ? tag.Member(scope.Name.Path)?.As<LogixScoped>() : result;
         return IsNull(target, out element);
     }
 
-    public bool TryGet<TObject>(Func<IScopeBuilder, Scope> builder, out TObject element) where TObject : LogixObject
+    public bool TryGet<TScoped>(Func<IScopeBuilder, Scope> builder, out TScoped element) where TScoped : LogixScoped
     {
         if (builder is null)
             throw new ArgumentNullException(nameof(builder));
@@ -228,9 +228,9 @@ internal class LogixIndex : ILogixLookup
             return false;
         }
 
-        var result = value.Deserialize<TObject>();
+        var result = value.Deserialize<TScoped>();
         var target = result is Tag tag ? tag.Member(scope.Name.Path)?.As<LogixObject>() : result;
-        return IsNull(target as TObject, out element);
+        return IsNull(target as TScoped, out element);
     }
 
     public IEnumerable<CrossReference> References(TagName name)
@@ -491,7 +491,7 @@ internal class LogixIndex : ILogixLookup
     /// Generates all potential scope paths for the provided type and name so that we can attempt to find all instances
     /// of an element across alls scopes.
     /// </summary>
-    private IEnumerable<Scope> GenerateScopes(ScopeType type, string name)
+    private List<Scope> GenerateScopes(ScopeType type, string name)
     {
         if (string.IsNullOrEmpty(name))
             throw new ArgumentException(

--- a/src/L5Sharp.Core/LogixLookup.cs
+++ b/src/L5Sharp.Core/LogixLookup.cs
@@ -35,17 +35,17 @@ internal class LogixLookup(XElement content) : ILogixLookup
         return element is not null;
     }
 
-    public IEnumerable<LogixObject> Find(Scope scope)
+    public IEnumerable<LogixScoped> Find(Scope scope)
     {
         if (scope is null)
             throw new ArgumentNullException(nameof(scope));
 
-        var results = new List<LogixObject>();
+        var results = new List<LogixScoped>();
         var scopes = GenerateScopes(scope.Type, scope.Name);
 
         foreach (var path in scopes)
         {
-            var element = content.XPathSelectElement(path.ToXPath())?.Deserialize<LogixObject>();
+            var element = content.XPathSelectElement(path.ToXPath())?.Deserialize<LogixScoped>();
             var result = element is Tag tag ? tag.Member(scope.Name.Path) : element;
             if (result is null) continue;
             results.Add(result);
@@ -54,27 +54,27 @@ internal class LogixLookup(XElement content) : ILogixLookup
         return results;
     }
 
-    public IEnumerable<TObject> Find<TObject>(Scope scope) where TObject : LogixObject
+    public IEnumerable<TScoped> Find<TScoped>(Scope scope) where TScoped : LogixScoped
     {
         if (scope is null)
             throw new ArgumentNullException(nameof(scope));
 
-        var results = new List<TObject>();
-        var type = scope.Type != ScopeType.Empty ? scope.Type : ScopeType.Parse(typeof(TObject).L5XType());
+        var results = new List<TScoped>();
+        var type = scope.Type != ScopeType.Empty ? scope.Type : ScopeType.Parse(typeof(TScoped).L5XType());
         var scopes = GenerateScopes(type, scope.Name.Root);
 
         foreach (var path in scopes)
         {
-            var element = content.XPathSelectElement(path.ToXPath())?.Deserialize<TObject>();
+            var element = content.XPathSelectElement(path.ToXPath())?.Deserialize<TScoped>();
             var result = element is Tag tag ? tag.Member(scope.Name.Path) as LogixObject : element;
-            if (result is not TObject typed) continue;
+            if (result is not TScoped typed) continue;
             results.Add(typed);
         }
 
         return results;
     }
 
-    public LogixObject Get(Scope scope)
+    public LogixScoped Get(Scope scope)
     {
         if (scope is null)
             throw new ArgumentNullException(nameof(scope));
@@ -85,26 +85,26 @@ internal class LogixLookup(XElement content) : ILogixLookup
         if (element is null)
             throw new KeyNotFoundException($"No element with the provided scope was found: {key}");
 
-        var result = element.Deserialize<LogixObject>();
+        var result = element.Deserialize<LogixScoped>();
         return result is Tag tag ? tag[key.Name.Path] : result;
     }
 
-    public TObject Get<TObject>(Scope scope) where TObject : LogixObject
+    public TScoped Get<TScoped>(Scope scope) where TScoped : LogixScoped
     {
         if (scope is null)
             throw new ArgumentNullException(nameof(scope));
 
-        var key = GenerateAbsolute(scope, typeof(TObject));
+        var key = GenerateAbsolute(scope, typeof(TScoped));
         var element = content.XPathSelectElement(key.ToXPath());
 
         if (element is null)
             throw new KeyNotFoundException($"No element with the provided scope was found: {key}");
 
-        var result = element.Deserialize<TObject>();
-        return result is Tag tag ? (TObject)(LogixObject)tag[key.Name.Path] : result;
+        var result = element.Deserialize<TScoped>();
+        return result is Tag tag ? (TScoped)(LogixObject)tag[key.Name.Path] : result;
     }
 
-    public LogixObject Get(Func<IScopeBuilder, Scope> builder)
+    public LogixScoped Get(Func<IScopeBuilder, Scope> builder)
     {
         if (builder is null)
             throw new ArgumentNullException(nameof(builder));
@@ -117,11 +117,11 @@ internal class LogixLookup(XElement content) : ILogixLookup
         if (element is null)
             throw new KeyNotFoundException($"No element with the provided scope was found: {scope}");
 
-        var result = element.Deserialize<LogixObject>();
+        var result = element.Deserialize<LogixScoped>();
         return result is Tag tag ? tag[scope.Name.Path] : result;
     }
 
-    public TObject Get<TObject>(Func<IScopeBuilder, Scope> builder) where TObject : LogixObject
+    public TScoped Get<TScoped>(Func<IScopeBuilder, Scope> builder) where TScoped : LogixScoped
     {
         if (builder is null)
             throw new ArgumentNullException(nameof(builder));
@@ -134,18 +134,18 @@ internal class LogixLookup(XElement content) : ILogixLookup
         if (element is null)
             throw new KeyNotFoundException($"No element with the provided scope was found: {scope}");
 
-        var result = element.Deserialize<TObject>();
-        return result is Tag tag ? (TObject)(LogixObject)tag[scope.Name.Path] : result;
+        var result = element.Deserialize<TScoped>();
+        return result is Tag tag ? (TScoped)(LogixObject)tag[scope.Name.Path] : result;
     }
 
-    public bool TryGet(Scope scope, out LogixObject element)
+    public bool TryGet(Scope scope, out LogixScoped element)
     {
         if (scope is null)
             throw new ArgumentNullException(nameof(scope));
 
         var key = GenerateAbsolute(scope);
 
-        var result = content.XPathSelectElement(key.ToXPath())?.Deserialize<LogixObject>();
+        var result = content.XPathSelectElement(key.ToXPath())?.Deserialize<LogixScoped>();
 
         if (result is null)
         {
@@ -157,14 +157,14 @@ internal class LogixLookup(XElement content) : ILogixLookup
         return IsNull(target, out element);
     }
 
-    public bool TryGet<TObject>(Scope scope, out TObject element) where TObject : LogixObject
+    public bool TryGet<TScoped>(Scope scope, out TScoped element) where TScoped : LogixScoped
     {
         if (scope is null)
             throw new ArgumentNullException(nameof(scope));
 
-        var key = GenerateAbsolute(scope, typeof(TObject));
+        var key = GenerateAbsolute(scope, typeof(TScoped));
 
-        var result = content.XPathSelectElement(key.ToXPath())?.Deserialize<TObject>();
+        var result = content.XPathSelectElement(key.ToXPath())?.Deserialize<TScoped>();
 
         if (result is null)
         {
@@ -173,10 +173,10 @@ internal class LogixLookup(XElement content) : ILogixLookup
         }
 
         var target = result is Tag tag ? tag.Member(key.Name.Path)?.As<LogixObject>() : result;
-        return IsNull(target as TObject, out element);
+        return IsNull(target as TScoped, out element);
     }
 
-    public bool TryGet(Func<IScopeBuilder, Scope> builder, out LogixObject element)
+    public bool TryGet(Func<IScopeBuilder, Scope> builder, out LogixScoped element)
     {
         if (builder is null)
             throw new ArgumentNullException(nameof(builder));
@@ -184,7 +184,7 @@ internal class LogixLookup(XElement content) : ILogixLookup
         var root = Scope.Build(content.LogixName());
         var scope = builder(root);
 
-        var result = content.XPathSelectElement(scope.ToXPath())?.Deserialize<LogixObject>();
+        var result = content.XPathSelectElement(scope.ToXPath())?.Deserialize<LogixScoped>();
 
         if (result is null)
         {
@@ -196,7 +196,7 @@ internal class LogixLookup(XElement content) : ILogixLookup
         return IsNull(target, out element);
     }
 
-    public bool TryGet<TObject>(Func<IScopeBuilder, Scope> builder, out TObject element) where TObject : LogixObject
+    public bool TryGet<TScoped>(Func<IScopeBuilder, Scope> builder, out TScoped element) where TScoped : LogixScoped
     {
         if (builder is null)
             throw new ArgumentNullException(nameof(builder));
@@ -204,7 +204,7 @@ internal class LogixLookup(XElement content) : ILogixLookup
         var root = Scope.Build(content.LogixName());
         var scope = builder(root);
 
-        var result = content.XPathSelectElement(scope.ToXPath())?.Deserialize<TObject>();
+        var result = content.XPathSelectElement(scope.ToXPath())?.Deserialize<TScoped>();
 
         if (result is null)
         {
@@ -213,7 +213,7 @@ internal class LogixLookup(XElement content) : ILogixLookup
         }
 
         var target = result is Tag tag ? tag.Member(scope.Name.Path)?.As<LogixObject>() : result;
-        return IsNull(target as TObject, out element);
+        return IsNull(target as TScoped, out element);
     }
 
     public IEnumerable<CrossReference> References(TagName name) => [];
@@ -226,7 +226,7 @@ internal class LogixLookup(XElement content) : ILogixLookup
     /// Generates all potential scope paths for the provided type and name so that we can attempt to find all instances
     /// of an element across alls scopes.
     /// </summary>
-    private IEnumerable<Scope> GenerateScopes(ScopeType type, string name)
+    private List<Scope> GenerateScopes(ScopeType type, string name)
     {
         if (string.IsNullOrEmpty(name))
             throw new ArgumentException(

--- a/src/L5Sharp.Core/LogixScoped.cs
+++ b/src/L5Sharp.Core/LogixScoped.cs
@@ -1,0 +1,34 @@
+﻿using System.Xml.Linq;
+
+namespace L5Sharp.Core;
+
+/// <summary>
+/// 
+/// </summary>
+public abstract class LogixScoped : LogixObject
+{
+    /// <inheritdoc />
+    protected LogixScoped(string name) : base(name)
+    {
+    }
+
+    /// <inheritdoc />
+    protected LogixScoped(XElement element) : base(element)
+    {
+    }
+    
+    /// <summary>
+    /// The scope idetifying where in an L5X file this element exists. This can be a globally scoped controller element,
+    /// a locally scoped program or instruction element, or neither (not attached to L5X tree).
+    /// </summary>
+    /// <value>A <see cref="Scope"/> object with information regarding the scope of the element.</value>
+    /// <remarks>
+    /// <para>
+    /// The scope of an element is determined from the ancestors of the underlying <see cref="XElement"/>.
+    /// This property is not inherent in the underlying XML (not serialized), but one that adds a lot of
+    /// value as it helps uniquely identify elements within the L5X file, especially elements such as <c>Tag</c>,
+    /// <c>Routine</c>, or <c>Rung</c>.
+    /// </para>
+    /// </remarks>
+    public Scope Scope => Scope.Of(Element);
+}


### PR DESCRIPTION
Moved Scope into new Class called LogixScoped and updated the ILogixLookup API to reflect this. LogixScoped is not the elements that should support Scope property which includes components and code elements. Also updated documentation.