### PR TITLE
Feature/40 string virtual members

### DIFF
--- a/src/L5Sharp.Core/Common/Scope.cs
+++ b/src/L5Sharp.Core/Common/Scope.cs
@@ -510,9 +510,8 @@ public sealed class Scope
     /// </summary>
     private static ScopeType GetScopedType(XElement element)
     {
-        //Intercent knwon tag elements or nested tag data elements
-        if (element.AncestorsAndSelf().Any(e => e.L5XType() 
-                is L5XName.Tag or L5XName.LocalTag or L5XName.ConfigTag or L5XName.InputTag or L5XName.OutputTag))
+        //Intercent knwon tag elements types (not sure how else to do this ATM)
+        if (element.L5XType() is L5XName.LocalTag or L5XName.ConfigTag or L5XName.InputTag or L5XName.OutputTag)
         {
             return ScopeType.Tag;
         }
@@ -525,9 +524,8 @@ public sealed class Scope
     /// </summary>
     private static string GetScopedName(XElement element)
     {
-        //Intercent knwon tag elements or nested tag data elements
-        if (element.AncestorsAndSelf().Any(e => e.L5XType() 
-                is L5XName.Tag or L5XName.LocalTag or L5XName.ConfigTag or L5XName.InputTag or L5XName.OutputTag))
+        //Intercent knwon tag elements types (not sure how else to do this ATM)
+        if (element.L5XType() is L5XName.LocalTag or L5XName.ConfigTag or L5XName.InputTag or L5XName.OutputTag)
         {
             return element.TagName();
         }

--- a/src/L5Sharp.Core/Common/Scope.cs
+++ b/src/L5Sharp.Core/Common/Scope.cs
@@ -510,19 +510,33 @@ public sealed class Scope
     /// </summary>
     private static ScopeType GetScopedType(XElement element)
     {
+        //Intercent knwon tag elements or nested tag data elements
+        if (element.AncestorsAndSelf().Any(e => e.L5XType() 
+                is L5XName.Tag or L5XName.LocalTag or L5XName.ConfigTag or L5XName.InputTag or L5XName.OutputTag))
+        {
+            return ScopeType.Tag;
+        }
+        
         return ScopeType.TryParse(element.L5XType()) ?? ScopeType.Empty;
     }
 
     /// <summary>
     /// Gets the name or number of the current element depending on which attribute exists.
     /// </summary>
-    private static string GetScopedName(XElement node)
+    private static string GetScopedName(XElement element)
     {
-        if (node.Attribute(L5XName.Name) is not null)
-            return node.LogixName();
+        //Intercent knwon tag elements or nested tag data elements
+        if (element.AncestorsAndSelf().Any(e => e.L5XType() 
+                is L5XName.Tag or L5XName.LocalTag or L5XName.ConfigTag or L5XName.InputTag or L5XName.OutputTag))
+        {
+            return element.TagName();
+        }
+        
+        if (element.Attribute(L5XName.Name) is not null)
+            return element.LogixName();
 
-        return node.Attribute(L5XName.Number) is not null
-            ? node.Attribute(L5XName.Number)?.Value ?? string.Empty
+        return element.Attribute(L5XName.Number) is not null
+            ? element.Attribute(L5XName.Number)?.Value ?? string.Empty
             : string.Empty;
     }
 

--- a/src/L5Sharp.Core/Components/Tag.cs
+++ b/src/L5Sharp.Core/Components/Tag.cs
@@ -171,7 +171,13 @@ public class Tag : LogixComponent<Tag>
     }
 
     /// <inheritdoc />
-    public override Scope Scope => Parent is null ? Scope.Of(Element) : Scope.Of(_member.Serialize());
+    /// <remarks>
+    /// Tag overrides Scope to ensure nested tag members build the correct scope path that includes
+    /// the full <see cref="TagName"/>.
+    /// </remarks>
+    public override Scope Scope => Parent is null
+        ? Scope.Of(Element)
+        : Scope.To($"{Parent.Scope.Controller}/{Parent.Scope.Program}/{ScopeType.Tag}/{TagName}");
 
     /// <summary>
     /// The name of the data type the tag represents. 

--- a/src/L5Sharp.Core/Components/Tag.cs
+++ b/src/L5Sharp.Core/Components/Tag.cs
@@ -45,7 +45,7 @@ public class Tag : LogixComponent<Tag>
     /// </summary>
     public Tag() : base(L5XName.Tag)
     {
-        //The root tag will contain a "virtual" which will simply routine calls to it's local get/set data functions.
+        //The root tag will contain a "virtual" which will simply routine calls to its local get/set data functions.
         _member = new Member(Element.LogixName(), GetData, SetData);
         Root = this;
         TagType = TagType.Base;
@@ -60,7 +60,7 @@ public class Tag : LogixComponent<Tag>
     /// <exception cref="ArgumentNullException"><c>element</c> is null.</exception>
     public Tag(XElement element) : base(element)
     {
-        //The root tag will contain a "virtual" which will simply routine calls to it's local get/set data functions.
+        //The root tag will contain a "virtual" which will simply routine calls to its local get/set data functions.
         _member = new Member(Element.LogixName(), GetData, SetData);
         Root = this;
     }
@@ -102,7 +102,7 @@ public class Tag : LogixComponent<Tag>
     /// <param name="element">the name of the tag element.</param>
     protected Tag(string element) : base(element)
     {
-        //The root tag will contain a "virtual" which will simply routine calls to it's local get/set data functions.
+        //The root tag will contain a "virtual" which will simply routine calls to its local get/set data functions.
         _member = new Member(Element.LogixName(), GetData, SetData);
         Root = this;
         TagType = TagType.Base;
@@ -170,6 +170,9 @@ public class Tag : LogixComponent<Tag>
         set => SetTagDescription(value);
     }
 
+    /// <inheritdoc />
+    public override Scope Scope => Parent is null ? Scope.Of(Element) : Scope.Of(_member.Serialize());
+
     /// <summary>
     /// The name of the data type the tag represents. 
     /// </summary>
@@ -182,7 +185,7 @@ public class Tag : LogixComponent<Tag>
     public string DataType => Value.Name;
 
     /// <summary>
-    /// The dimensions of the tag, indicating the length and dimensions of it's array.
+    /// The dimensions of the tag, indicating the length and dimensions of its array.
     /// </summary>
     /// <value>A <see cref="Core.Dimensions"/> value representing the array dimensions of the tag.</value>
     /// <remarks>
@@ -238,6 +241,7 @@ public class Tag : LogixComponent<Tag>
     /// The external access option indicating the read/write access of the tag from OPC UA.
     /// </summary>
     /// <value>A <see cref="Core.OpcUAAccess"/> option representing read/write access of the tag from OPC UA.</value>
+    // ReSharper disable once InconsistentNaming we need the name to match.
     public OpcUAAccess? OpcUAAccess
     {
         get => GetValue<OpcUAAccess>();
@@ -339,7 +343,7 @@ public class Tag : LogixComponent<Tag>
     /// The parent tag of this <see cref="Tag"/> member.
     /// </summary>
     /// <value>
-    /// A <see cref="Tag"/> representing the immediate parent tag of the this tag member. Will be <c>null</c>
+    /// A <see cref="Tag"/> representing the immediate parent tag of this tag member. Will be <c>null</c>
     /// for all root tag objects.
     /// </value>
     /// <remarks>
@@ -409,7 +413,7 @@ public class Tag : LogixComponent<Tag>
     /// <remarks>
     /// <para>
     /// This will always operate over the root EngineeringUnits element, regardless from which tag member object
-    /// this is called from. The caller is responsible for ensuring proper configuration of the units collection.
+    /// this is called from. The caller is responsible for ensuring proper configuration of the units' collection.
     /// </para>
     /// <para>
     /// Note that setting <see cref="Unit"/> from a given tag or nested tag member will update this collection
@@ -464,7 +468,7 @@ public class Tag : LogixComponent<Tag>
     /// <exception cref="InvalidOperationException">The current tag does not contain a mutable complex logix type.</exception>
     /// <remarks>
     /// This will operate relative to the current tag member object, and is simply a call to the underlying
-    /// <see cref="ComplexData"/> <c>Add</c> method. Therefore this is simply a helper to make mutating tag structures
+    /// <see cref="ComplexData"/> <c>Add</c> method. Therefore, this is simply a helper to make mutating tag structures
     /// more concise.
     /// </remarks>
     public void Add(string name, LogixData value)
@@ -552,7 +556,7 @@ public class Tag : LogixComponent<Tag>
     }
 
     /// <summary>
-    /// Gets this and all descendent tag members of the tag data structure that that satisfy the specified tag predicate.
+    /// Gets this and all descendent tag members of the tag data structure that satisfy the specified tag predicate.
     /// </summary>
     /// <param name="predicate">A predicate expression specifying the tag filter.</param>
     /// <returns>A <see cref="IEnumerable{T}"/> containing <see cref="Tag"/> objects that satisfy the predicate.</returns>
@@ -592,7 +596,7 @@ public class Tag : LogixComponent<Tag>
         if (tagName.IsEmpty) return Members();
 
         var member = Value.Member(tagName.Root);
-        if (member is null) return Enumerable.Empty<Tag>();
+        if (member is null) return [];
 
         var tag = new Tag(Root, member, this);
         var remaining = TagName.Combine(tagName.Members.Skip(1));
@@ -615,7 +619,7 @@ public class Tag : LogixComponent<Tag>
     /// <exception cref="InvalidOperationException">The current tag does not contain a mutable complex logix type.</exception>
     /// <remarks>
     /// This will operate relative to the current tag member object, and is simply a call to the underlying
-    /// <see cref="ComplexData"/> <c>Remove</c> method. Therefore this is simply a helper to make mutating tag structures
+    /// <see cref="ComplexData"/> <c>Remove</c> method. Therefore, this is simply a helper to make mutating tag structures
     /// more concise.
     /// </remarks>
     public void Remove(string name)
@@ -631,7 +635,7 @@ public class Tag : LogixComponent<Tag>
     /// this <c>Tag</c>. 
     /// </summary>
     /// <returns>
-    /// A <see cref="IEnumerable{T}"/> of <see cref="TagName"/> containing the this tag name and all child tag names.
+    /// A <see cref="IEnumerable{T}"/> of <see cref="TagName"/> containing the tag name and all child tag names.
     /// </returns>
     public IEnumerable<TagName> TagNames() => Members().Select(t => t.TagName);
 
@@ -646,7 +650,7 @@ public class Tag : LogixComponent<Tag>
     /// A <see cref="Tag"/> with the same underlying <see cref="XElement"/> and corresponding properties with
     /// <see cref="Value"/> changed to the provided <see cref="LogixData"/>.
     /// </returns>
-    /// <exception cref="InvalidOperationException">When this tag is a nested tag member and it's parent tag's
+    /// <exception cref="InvalidOperationException">When this tag is a nested tag member, and it's parent tag's
     /// <see cref="Value"/> property is not a <see cref="ComplexData"/> object.</exception>
     /// <remarks>
     /// <para>

--- a/src/L5Sharp.Core/Data/Predefined/STRING.cs
+++ b/src/L5Sharp.Core/Data/Predefined/STRING.cs
@@ -32,10 +32,6 @@ public sealed class STRING : StringData, ILogixParsable<STRING>
     {
     }
 
-    /// <inheritdoc />
-    //This is the length of the predefined STRING type in Logix
-    protected override ushort MaxLength => 82;
-
     /// <summary>
     /// Parses the provided string into a <see cref="STRING"/> value.
     /// </summary>

--- a/src/L5Sharp.Core/Data/StringData.cs
+++ b/src/L5Sharp.Core/Data/StringData.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -8,13 +7,14 @@ using System.Xml.Linq;
 namespace L5Sharp.Core;
 
 /// <summary>
-/// A <see cref="LogixData"/> that represents a string or collection of ASCII characters.
+/// A <see cref="LogixData"/> type that represents a string or collection of ASCII characters.
 /// </summary>
 /// <remarks>
 /// <para>
 /// A logix string type has predefined members <see cref="LEN"/> and <see cref="DATA"/>, which contain the
 /// current string length and set of ASCII characters representing the string value, respectively.
 /// This class is inherited by <see cref="STRING"/>, which is Rockwell's built-in base string type.
+/// Users can derive from this base class to create user defined string types if desired.
 /// </para>
 /// <para>
 /// <see cref="StringData"/> will not pass the provided element to the base class but rather extract
@@ -24,30 +24,23 @@ namespace L5Sharp.Core;
 /// as if they are immutable values types.
 /// </para>
 /// </remarks>
-public class StringData : StructureData, IEnumerable<char>
+public class StringData : StructureData, IEnumerable<SINT>
 {
+    /// <summary>
+    /// The pattern that extracts the ASCII character segments from a string value.
+    /// </summary>
     private static readonly Regex LogixAsciiPattern = new(@"\$[A-Fa-f0-9]{2}|\$[tlpr'$]{1}|[\x00-\x7F]");
-    private readonly SINT[] _data;
+
+    /// <summary>
+    /// The underlying string value for the type.
+    /// </summary>
+    private readonly string _value;
 
     /// <inheritdoc />
     public StringData(XElement element) : base(new XElement(L5XName.Data))
     {
         Name = element.DataType() ?? string.Empty;
-        _data = GenerateData(GetDataArray(GetStringValue(element)));
-    }
-
-    /// <summary>
-    /// Creates a new <see cref="StringData"/> initialized with the provided string type name and data value. 
-    /// </summary>
-    /// <param name="value">The value of the string data type. If null then defaults to an empty string.</param>
-    /// <remarks>
-    /// This constructor allows the caller to create a generic string type instance that could represent a
-    /// user defined string type class without having to actually create a custom class.
-    /// </remarks>
-    public StringData(string? value) : base(new XElement(L5XName.Data))
-    {
-        Name = string.Empty;
-        _data = GenerateData(GetDataArray(value ?? string.Empty));
+        _value = GetStringValue(element);
     }
 
     /// <summary>
@@ -62,73 +55,59 @@ public class StringData : StructureData, IEnumerable<char>
     public StringData(string? name, string? value) : base(new XElement(L5XName.Data))
     {
         Name = name ?? string.Empty;
-        _data = GenerateData(GetDataArray(value ?? string.Empty));
+        _value = ParseValue(value);
     }
 
     /// <inheritdoc />
     public override string Name { get; }
 
-    /// <inheritdoc />
-    public override IEnumerable<Member> Members => GenerateVirtualMembers();
-
     /// <summary>
     /// Gets the current length of the string value.
     /// </summary>
     /// <value>A <see cref="DINT"/> value representing the integer length of the string value.</value>
-    public DINT LEN => ToString().Length;
+    /// <remarks>
+    /// This member property is not returned in the <c>Members</c> collection because it is not serialized.
+    /// It would also generate an extemely large number of member tags, which would consume more memeory.
+    /// To reduce space/file size, Rockwell formats strings as a single element value in a Data member element.
+    /// This property is only here as a helper to allow the caller to conveniently obtain the length of the
+    /// underlying string value.
+    /// </remarks>
+    public DINT LEN => _value.Length;
 
     /// <summary>
     /// Gets the array of <see cref="SINT"/> characters that represent the ASCII encoded string value.
     /// </summary>
     /// <returns>An array of <see cref="SINT"/> logix atomic values representing the bytes of the string.</returns>
-    public ArrayData<SINT> DATA => new(_data);
-
-    /// <summary>
-    /// The maximum length of characters the <see cref="StringData"/> derivative can hold in <see cref="DATA"/>.
-    /// </summary>
     /// <remarks>
-    /// By default, this will be '0' since we can't know the max length for some arbitrary string type. The code internally
-    /// will construct the array to the size of the incoming string value if set to <c>0</c>. If greater than zero then
-    /// <see cref="DATA"/> will be initialized to that length and filled with the incoming value array.
+    /// This member property is not returned in the <c>Members</c> collection because it is not serialized.
+    /// It would also generate an extemely large number of member tags, which would consume more memeory.
+    /// To reduce space/file size, Rockwell formats strings as a single element value in a Data or DataValueMember element.
+    /// This property is only here as a helper to allow the caller to conveniently obtain the SINT array
+    /// representation of the underlying string by converting the underlying value.
     /// </remarks>
-    protected virtual ushort MaxLength => 0;
-
-    /// <summary>
-    /// Returns the actual string value of the <see cref="StringData"/> object without single quotes and special
-    /// Logix escape character(s) ('$').
-    /// </summary>
-    /// <returns>The <see cref="string"/> containing the value of the string type object.</returns>
-    public override string ToString()
-    {
-        var ascii = _data.Where(s => s > 0).Select(s => s.ToString(Radix.Ascii).TrimSingle('\''));
-        return $"{string.Join(string.Empty, ascii)}";
-    }
+    public ArrayData<SINT> DATA => ToDataArray(_value);
 
     /// <inheritdoc />
     public override bool Equals(object? obj)
     {
         return obj switch
         {
-            StringData value => ToString() == value.ToString(),
-            string value => ToString() == value,
+            StringData value => _value == value._value,
+            string value => _value == value,
             _ => false
         };
     }
 
     /// <inheritdoc />
-    public override int GetHashCode() => ToString().GetHashCode();
+    public override int GetHashCode() => _value.GetHashCode();
 
     /// <inheritdoc />
-    public IEnumerator<char> GetEnumerator() => ToString().GetEnumerator();
+    public override string ToString() => _value;
+
+    /// <inheritdoc />
+    public IEnumerator<SINT> GetEnumerator() => ToDataArray(_value).ToList().GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-    /// <summary>
-    /// Converts the provided <see cref="StringData"/> to a <see cref="string"/> value.
-    /// </summary>
-    /// <param name="input">The value to convert.</param>
-    /// <returns>A <see cref="string"/> type value.</returns>
-    public static implicit operator string(StringData input) => input.ToString();
 
     /// <inheritdoc />
     public override XElement Serialize()
@@ -136,7 +115,7 @@ public class StringData : StructureData, IEnumerable<char>
         var element = new XElement(L5XName.Data);
         element.Add(new XAttribute(L5XName.Format, DataFormat.String));
         element.Add(new XAttribute(L5XName.Length, LEN));
-        element.Add(new XCData($"'{ToString()}'"));
+        element.Add(new XCData($"'{_value}'"));
         return element;
     }
 
@@ -165,51 +144,10 @@ public class StringData : StructureData, IEnumerable<char>
         data.Add(new XAttribute(L5XName.Name, nameof(DATA)));
         data.Add(new XAttribute(L5XName.DataType, Name));
         data.Add(new XAttribute(L5XName.Radix, Radix.Ascii));
-        data.Add(new XCData($"'{ToString()}'"));
+        data.Add(new XCData($"'{_value}'"));
         element.Add(data);
 
         return element;
-    }
-
-    /// <summary>
-    /// Generates the "virtual" data members for the <see cref="StringData"/>. All string types have
-    /// the LEN and DATA member which contain the length and array of ASCII characters. We will allow these to be
-    /// retrieved as nested data members, but they have no setter. This is because of how strings are serialized. Strings
-    /// are treated as immutable types like Atomics. You only update their value on a tag or member which will know
-    /// how to update the corresponding data element. You can not update the member values. This is actually how
-    /// Logix Designer works as well.
-    /// </summary>
-    private IEnumerable<Member> GenerateVirtualMembers()
-    {
-        const string message = "Set the string value for the parent tag to update this value.";
-
-        yield return new Member(nameof(LEN), () => LEN,
-            _ => throw new InvalidOperationException(
-                $"The LEN member for {typeof(StringData)} objects is read only. {message}."));
-        yield return new Member(nameof(DATA), () => DATA,
-            _ => throw new InvalidOperationException(
-                $"The DATA member for {typeof(StringData)} objects is read only. {message}."));
-    }
-
-    /// <summary>
-    /// Generates an array type with the predefined length and initializes the array to the provided array. Will fill
-    /// remaining array with default '0' SINT values with ASCII format.
-    /// </summary>
-    // ReSharper disable once SuggestBaseTypeForParameter I don't care.
-    private SINT[] GenerateData(SINT[] array)
-    {
-        //If there is no specified MaxLength (meaning this is a generic StringType) then use the provided array length.
-        var length = MaxLength > 0 ? MaxLength : array.Length;
-
-        var data = new SINT[length];
-
-        //Populate the generated DATA array with the provided array.
-        for (var i = 0; i < length; i++)
-        {
-            data[i] = i < array.Length ? new SINT(array[i], Radix.Ascii) : new SINT(Radix.Ascii);
-        }
-
-        return data;
     }
 
     /// <summary>
@@ -220,20 +158,34 @@ public class StringData : StructureData, IEnumerable<char>
     private static string GetStringValue(XElement element)
     {
         if (element.Name == L5XName.Data && element.Attribute(L5XName.Format)?.Value == DataFormat.String)
-            return element.Value;
+        {
+            return ParseValue(element.Value.TrimStart('\'').TrimEnd('\''));
+        }
 
         var data = element.Elements().FirstOrDefault(e => e.MemberName() == nameof(DATA));
-        return data is not null ? data.Value : string.Empty;
+        return data is not null ? ParseValue(data.Value.TrimStart('\'').TrimEnd('\'')) : string.Empty;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    private static string ParseValue(string? input)
+    {
+        if (input is null) return string.Empty;
+        var data = ToDataArray(input);
+        var ascii = data.Where(s => s > 0).Select(s => s.ToString(Radix.Ascii).TrimSingle('\''));
+        return $"{string.Join(string.Empty, ascii)}";
     }
 
     /// <summary>
     /// Converts the provided string value to a SINT array. Handles empty or null string by returning empty array.
-    /// Trims start and end single quotes. Matches characters using known <see cref="LogixAsciiPattern"/>.
+    /// Matches characters using known <see cref="LogixAsciiPattern"/>.
+    /// Trims start and end single quotes.
     /// </summary>
-    private static SINT[] GetDataArray(string value)
+    private static SINT[] ToDataArray(string value)
     {
         var result = new List<SINT>();
-        
+
         //Logix encloses strings in single quotes, so we need to remove those if they are present.
         value = value.TrimStart('\'').TrimEnd('\'');
 

--- a/src/L5Sharp.Core/L5Sharp.Core.csproj
+++ b/src/L5Sharp.Core/L5Sharp.Core.csproj
@@ -7,9 +7,9 @@
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
         <Title>L5Sharp</Title>
         <Authors>Timothy Nunnink</Authors>
-        <Version>4.1.0</Version>
-        <AssemblyVersion>4.1.0</AssemblyVersion>
-        <FileVersion>4.1.0.0</FileVersion>
+        <Version>4.2.0</Version>
+        <AssemblyVersion>4.2.0</AssemblyVersion>
+        <FileVersion>4.2.0.0</FileVersion>
         <Description>A library for intuitively interacting with Rockwell's L5X import/export files.</Description>
         <RepositoryUrl>https://github.com/tnunnink/L5Sharp</RepositoryUrl>
         <PackageTags>csharp allen-bradely l5x logix plc-programming rockwell-automation logix5000</PackageTags>
@@ -18,7 +18,7 @@
         <!--<PackageIcon>icon.png</PackageIcon>-->
         <RepositoryType>git</RepositoryType>
         <PackageReleaseNotes>
-            Moves Scope to LogixScoped class which Component and Code now derive from.
+            Removed StringData virtual members.
         </PackageReleaseNotes>
         <Copyright>Copyright (c) Timothy Nunnink 2022</Copyright>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/L5Sharp.Core/LogixScoped.cs
+++ b/src/L5Sharp.Core/LogixScoped.cs
@@ -30,5 +30,5 @@ public abstract class LogixScoped : LogixObject
     /// <c>Routine</c>, or <c>Rung</c>.
     /// </para>
     /// </remarks>
-    public Scope Scope => Scope.Of(Element);
+    public virtual Scope Scope => Scope.Of(Element);
 }

--- a/tests/L5Sharp.Tests/Common/ScopeTests.cs
+++ b/tests/L5Sharp.Tests/Common/ScopeTests.cs
@@ -557,4 +557,17 @@ public class ScopeTests
 
         path.Should().Be("/Controller[@Name='MyController']/Tasks/Task[@Name='MainTask']");
     }
+
+    [Test]
+    public void PerformanceForLotsOfTagsGetAllTagMembers()
+    {
+        var content = L5X.Load(Known.Example);
+
+        var scopes = content.Query<Tag>()
+            .SelectMany(t => t.Members())
+            .ToList();
+
+        scopes.Should().NotBeEmpty();
+        Console.WriteLine(scopes.Count);
+    }
 }

--- a/tests/L5Sharp.Tests/Common/ScopeTests.cs
+++ b/tests/L5Sharp.Tests/Common/ScopeTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Diagnostics;
+using FluentAssertions;
 
 namespace L5Sharp.Tests.Common;
 
@@ -557,17 +558,39 @@ public class ScopeTests
 
         path.Should().Be("/Controller[@Name='MyController']/Tasks/Task[@Name='MainTask']");
     }
+    
+    [Test]
+    public void PerformanceOfGettingAllTagMemberScopesShouldBeNotTerrible()
+    {
+        var content = L5X.Load(Known.Example);
+
+        var stopwatch = Stopwatch.StartNew();
+        
+        var scopes = content.Query<Tag>()
+            .SelectMany(t => t.Members())
+            .Select(t => t.Scope)
+            .ToList();
+        
+        stopwatch.Stop();
+        
+        
+        scopes.Should().NotBeEmpty();
+        Console.WriteLine(stopwatch.ElapsedMilliseconds);
+    }
 
     [Test]
-    public void PerformanceForLotsOfTagsGetAllTagMembers()
+    public void AllTagMembersShouldHaveTypeAndNameScopedProperty()
     {
         var content = L5X.Load(Known.Example);
 
         var scopes = content.Query<Tag>()
             .SelectMany(t => t.Members())
+            .Select(t => t.Scope)
             .ToList();
 
         scopes.Should().NotBeEmpty();
+        scopes.Should().AllSatisfy(s => s.Name.Should().NotBe(TagName.Empty));
+        scopes.Should().AllSatisfy(s => s.Type.Should().Be(ScopeType.Tag));
         Console.WriteLine(scopes.Count);
     }
 }

--- a/tests/L5Sharp.Tests/Components/TagTests.cs
+++ b/tests/L5Sharp.Tests/Components/TagTests.cs
@@ -641,27 +641,13 @@ public class TagTests
     }
 
     [Test]
-    public void Members_StringType_ShouldHaveExpectedCount()
+    public void Members_StringType_ShouldHaveSingleRootMember()
     {
         var tag = new Tag { Name = "Test", Value = "This is a test value" };
 
         var members = tag.Members().ToList();
 
-        members.Should().HaveCount(85);
-    }
-
-    [Test]
-    public void Members_StringType_ShouldHaveContainExpectedTagNames()
-    {
-        var tag = new Tag { Name = "Test", Value = "This is a test value" };
-
-        var members = tag.Members().ToList();
-
-        members.Should().Contain(t => t.TagName == "Test.LEN");
-        members.Should().Contain(t => t.TagName == "Test.DATA");
-        members.Should().Contain(t => t.TagName == "Test.DATA[0]");
-        members.Should().Contain(t => t.TagName == "Test.DATA[1]");
-        members.Should().Contain(t => t.TagName == "Test.DATA[63]");
+        members.Should().HaveCount(1);
     }
 
     [Test]
@@ -706,9 +692,7 @@ public class TagTests
         members.Should().Contain(t => t.TagName == "Test.Tmr.TT");
         members.Should().Contain(t => t.TagName == "Test.Tmr.ACC");
         members.Should().Contain(t => t.TagName == "Test.Tmr.PRE");
-        members.Should().Contain(t => t.TagName == "Test.Str.LEN");
-        members.Should().Contain(t => t.TagName == "Test.Str.DATA");
-        members.Should().Contain(t => t.TagName == "Test.Str.DATA[0]");
+        members.Should().Contain(t => t.TagName == "Test.Str");
     }
 
     [Test]
@@ -726,7 +710,7 @@ public class TagTests
     }
 
     [Test]
-    public void Members_TagNameWithMoreThanThreeMembers_ShouldReturnExpectedCount()
+    public void Members_TagNameWithMoreThanTwoMembers_ShouldReturnExpectedCount()
     {
         var tag = new Tag
         {
@@ -734,7 +718,7 @@ public class TagTests
             Value = new MyNestedData()
         };
 
-        var members = tag.Members(t => t.Members.Count() > 4);
+        var members = tag.Members(t => t.Members.Count() > 2);
 
         members.Should().NotBeEmpty();
     }

--- a/tests/L5Sharp.Tests/Data/MemberTests.cs
+++ b/tests/L5Sharp.Tests/Data/MemberTests.cs
@@ -152,8 +152,8 @@ public class MemberTests
 
         member.Name.Should().Be("Test");
         member.Value.Should().BeOfType<STRING>();
-        member.Value.Member("LEN")!.Value.Should().Be(27);
-        member.Value.ToString().Should().Be("This is a string type value");
+        member.Value.As<STRING>().LEN.Should().Be(27);
+        member.Value.As<STRING>().ToString().Should().Be("This is a string type value");
     }
 
     [Test]

--- a/tests/L5Sharp.Tests/Data/Predefined/StringTests.cs
+++ b/tests/L5Sharp.Tests/Data/Predefined/StringTests.cs
@@ -29,20 +29,9 @@ namespace L5Sharp.Tests.Data.Predefined
 
             type.Name.Should().Be("STRING");
             type.ToString().Should().BeEmpty();
-            type.LEN.Should().NotBeNull();
-            type.LEN.Should().BeOfType<DINT>();
-            type.DATA.Should().NotBeNull();
-            type.DATA.Should().BeOfType<ArrayData<SINT>>();
-            type.Members.Should().HaveCount(2);
-
-            var data = type.Members.FirstOrDefault(m => m.Name == "DATA");
-            data.Should().NotBeNull();
-            data?.Value.Should().NotBeNull();
-            data?.Value.Name.Should().NotBeNull();
-
-            var len = type.Members.FirstOrDefault(m => m.Name == "LEN");
-            len.Should().NotBeNull();
-            len?.Value.Should().NotBeNull();
+            type.LEN.Should().Be(0);
+            type.DATA.Should().BeEmpty();
+            type.Members.Should().BeEmpty();
         }
 
         [Test]
@@ -64,22 +53,16 @@ namespace L5Sharp.Tests.Data.Predefined
         [Test]
         public void New_AsciiStringValue_ShouldBeExpectedValue()
         {
+            //Sometimes Studio pads string with zero. Documentation says it does this but in my experience it is not consistent.
+            //I have not done enough testing to figure how/when it decides to do this.
+            //In any case, if we get input text like this I want to strip of the "empty" parts to just return the string value.
+            //The length is not really important to us.
+            //This tests validates the code that parses the string input as expected.
             const string text = "'$0B$00$00$00$00$00$00$00$00$00$00$00$00$00$00$00$00$00'";
 
             var type = new STRING(text);
 
             type.ToString().Should().Be("$0B");
-        }
-
-        [Test]
-        public void SetValue_OutOfRangeString_ShouldBeTruncated()
-        {
-            const string expected =
-                "This is a really long test string to see if the argument out of range exception will work. The string length must be less than eighty two characters in length. Do you think this is long enough?";
-
-            STRING type = expected;
-
-            type.ToString().Length.Should().BeLessThan(expected.Length);
         }
 
         [Test]

--- a/tests/L5Sharp.Tests/Data/StringDataTests.cs
+++ b/tests/L5Sharp.Tests/Data/StringDataTests.cs
@@ -7,25 +7,13 @@ namespace L5Sharp.Tests.Data;
 public class StringDataTests
 {
     [Test]
-    public void New_NameAndValueOverload_ShouldHaveExpectedValues()
-    {
-        var type = new StringData("MyStringType", "This is the test value");
-
-        type.Name.Should().Be("MyStringType");
-        type.ToString().Should().Be("This is the test value");
-        type.LEN.Should().Be(22);
-        type.DATA.Should().NotBeEmpty();
-        type.Members.Should().HaveCount(2);
-    }
-    
-    [Test]
     public void New_NullName_NameShouldBeEmpty()
     {
         var type = new StringData(null!, "This is the test value");
 
         type.Name.Should().BeEmpty();
     }
-    
+
     [Test]
     public void New_EmptyName_NameShouldBeEmpty()
     {
@@ -45,32 +33,40 @@ public class StringDataTests
     [Test]
     public void New_EmptyValue_ShouldBeEmpty()
     {
-        var type = new StringData("Test", "");
+        var type = new StringData("Test", string.Empty);
 
         type.ToString().Should().BeEmpty();
     }
 
     [Test]
-    public void New_ValueOverloadEmpty_ShouldBeExpected()
+    public void New_ValueOverload_NameShouldBeExpected()
     {
-        var type = new StringData(string.Empty);
-        
-        type.ToString().Should().BeEmpty();
+        var type = new StringData("MyStringType", "This is the value");
+
+        type.Name.Should().Be("MyStringType");
     }
 
     [Test]
-    public void New_ValueOverloadNonEmpty_ShouldBeExpected()
+    public void New_ValueOverload_ValueShouldBeExpected()
     {
-        var type = new StringData("This is the value");
-        
+        var type = new StringData("MyStringType", "This is the value");
+
         type.ToString().Should().Be("This is the value");
     }
-    
+
+    [Test]
+    public void New_ValueOverload_MembersShouldBeEmpty()
+    {
+        var type = new StringData("MyStringType", "This is the value");
+
+        type.Members.Should().BeEmpty();
+    }
+
     [Test]
     public void New_ValueOverload_ShouldHaveExpectedLength()
     {
-        var type = new StringData("This is the value");
-        
+        var type = new StringData("MyStringType", "This is the value");
+
         type.LEN.Should().Be(17);
         type.DATA.Dimensions.Length.Should().Be(17);
     }
@@ -138,52 +134,33 @@ public class StringDataTests
     [Test]
     public void ToString_Empty_ShouldBeExpected()
     {
-        var type = new StringData(string.Empty);
+        var type = new StringData("Test", string.Empty);
 
         var value = type.ToString();
 
         value.Should().Be("");
     }
-    
+
     [Test]
     public void ToString_ValueNoSpecialCharacters_ShouldBeExpected()
     {
-        var type = new StringData("This is a test");
+        var type = new StringData("Test", "This is a test");
 
         var value = type.ToString();
 
         value.Should().Be("This is a test");
     }
-    
+
     [Test]
     public void ToString_ValueSpecialCharacters_ShouldBeExpected()
     {
-        var type = new StringData("This is a $'special character$' test");
+        var type = new StringData("Test", "This is a $'special character$' test");
 
         var value = type.ToString();
 
         value.Should().Be("This is a $'special character$' test");
     }
 
-    [Test]
-    public void Members_GetValue_ShouldBeExpected()
-    {
-        var type = new StringData("TestType", "This is a test value");
-
-        var member = type.Members.ToList();
-
-        var len = member[0];
-        len.Name.Should().Be("LEN");
-        len.Value.Should().Be(20);
-
-        var data = member[1];
-        data.Name.Should().Be("DATA");
-        data.Value.Should().BeOfType<ArrayData<SINT>>();
-
-        var members = data.Value.Members.ToList();
-        members.Should().NotBeEmpty();
-    }
-    
     [Test]
     public void LEN_GetValueEmpty_ShouldBeExpected()
     {
@@ -203,7 +180,7 @@ public class StringDataTests
 
         len.Should().Be(14);
     }
-    
+
     [Test]
     public void DATA_GetValueEmpty_ShouldBeExpected()
     {
@@ -286,16 +263,6 @@ public class StringDataTests
         var code = type.GetHashCode();
 
         code.Should().Be(expected);
-    }
-
-    [Test]
-    public void Operator_StringType_ShouldBeExpected()
-    {
-        var type = new StringData("MyStringType", "This is a test");
-
-        string value = type;
-
-        value.Should().Be("This is a test");
     }
 
     [Test]


### PR DESCRIPTION
Scope and String Member Updates.

- Fixes Scope for Tag and nested tag member objects by overriding implementation and building using TagName.
- Removes the LEN and DATA from the Members collection for StringData to significantly reduce tag member count and improve performance.
- Fixes tests and updates documentation related.