### PR TITLE
Fix bit index handling and add related test cases

### DIFF
--- a/src/L5Sharp.Core/L5Sharp.Core.csproj
+++ b/src/L5Sharp.Core/L5Sharp.Core.csproj
@@ -9,8 +9,8 @@
         <Title>L5Sharp</Title>
         <Authors>Timothy Nunnink</Authors>
         <Version>4.8.1</Version>
-        <AssemblyVersion>4.8.1</AssemblyVersion>
-        <FileVersion>4.8.1.0</FileVersion>
+        <AssemblyVersion>4.8.2</AssemblyVersion>
+        <FileVersion>4.8.2.0</FileVersion>
         <Description>A library for intuitively interacting with Rockwell's L5X import/export files.</Description>
         <RepositoryUrl>https://github.com/tnunnink/L5Sharp</RepositoryUrl>
         <PackageTags>csharp allen-bradely l5x logix plc-programming rockwell-automation logix5000</PackageTags>

--- a/tests/L5Sharp.Tests.Core/Common/NeutralTextTests.cs
+++ b/tests/L5Sharp.Tests.Core/Common/NeutralTextTests.cs
@@ -11,14 +11,7 @@ namespace L5Sharp.Tests.Core.Common
 
         private const string Test02 =
             "GRT(SimpleInt,400)XIO(MultiDimensionalArray[1,3].3)CMP(ATN(_Test) > 1.0)[TON(TimerArray[0],?,?),OTU(TestComplexTag.SimpleMember.BoolMember)];";
-        
 
-        [Test]
-        public void Method_Scenario_ExpectedBehavior()
-        {
-           
-        }
-        
         [Test]
         public void New_NullText_ShouldThrowArgumentNullException()
         {
@@ -50,15 +43,15 @@ namespace L5Sharp.Tests.Core.Common
 
             text.Should().NotBeNull();
         }
-        
+
         [Test]
         public void IsBalanced_ValidText_ShouldBeTrue()
         {
             var text = new NeutralText("[XIC(SomeBit),XIO(AnotherBit)]OTE(OutputBit);");
-            
+
             text.IsBalanced.Should().BeTrue();
         }
-        
+
         [Test]
         public void IsBalanced_Unbalanced_ShouldBeFalse()
         {
@@ -66,7 +59,7 @@ namespace L5Sharp.Tests.Core.Common
 
             text.IsBalanced.Should().BeFalse();
         }
-        
+
         [Test]
         public void IsBalanced_TestText_ShouldBeTrue()
         {
@@ -114,7 +107,7 @@ namespace L5Sharp.Tests.Core.Common
 
             result.Should().BeTrue();
         }
-        
+
         [Test]
         public void Instructions_Empty_ShouldBeEmpty()
         {
@@ -124,7 +117,7 @@ namespace L5Sharp.Tests.Core.Common
 
             result.Should().BeEmpty();
         }
-        
+
         [Test]
         public void Instructions_SimpleTextWithMultipleInstruction_ShouldHaveExpectedCount()
         {
@@ -165,7 +158,7 @@ namespace L5Sharp.Tests.Core.Common
 
             result.First().Text.Should().Be(text);
         }
-        
+
         [Test]
         public void InstructionsBy_WithExistingInstructionPresent_ShouldContainExpectedText()
         {
@@ -188,14 +181,14 @@ namespace L5Sharp.Tests.Core.Common
 
             result.Should().HaveCount(1);
         }
-        
+
         [Test]
         public void Keywords_TextWithKeywords_ShouldHaveExpectedCount()
         {
             var text = new NeutralText("if Tag >= 10 then");
-            
+
             var keywords = text.Keywords().ToList();
-            
+
             keywords.Should().HaveCount(2);
         }
 
@@ -203,9 +196,9 @@ namespace L5Sharp.Tests.Core.Common
         public void Keywords_TextWithNoKeywords_ShouldBeEmpty()
         {
             var text = new NeutralText("[XIC(SomeBit),XIO(AnotherBit)]OTE(OutputBit);");
-            
+
             var keywords = text.Keywords().ToList();
-            
+
             keywords.Should().BeEmpty();
         }
 
@@ -228,7 +221,7 @@ namespace L5Sharp.Tests.Core.Common
 
             tagNames.Should().HaveCount(1);
         }
-        
+
         [Test]
         public void StructuredText_New_ShouldNotBeNull()
         {
@@ -236,7 +229,7 @@ namespace L5Sharp.Tests.Core.Common
 
             text.Should().NotBeNull();
         }
-        
+
         [Test]
         public void StructuredText_ShouldHaveExpected()
         {
@@ -246,6 +239,18 @@ namespace L5Sharp.Tests.Core.Common
             text.IsBalanced.Should().BeTrue();
             text.Instructions().Should().BeEmpty();
             text.Tags().Should().HaveCount(2);
+        }
+
+        [Test]
+        [Description("GitHub Issue #52: A tag with a bit index reference tag should parse correctly")]
+        public void Instructions_BitReferenceIndexTag_ShouldReturnExpectedInstruction()
+        {
+            var text = new NeutralText("XIC(DintTest.[Offset]);");
+
+            var instructions = text.Instructions().ToList();
+
+            instructions.Should().HaveCount(1);
+            instructions[0].Tags.Should().Contain("DintTest.[Offset]");
         }
     }
 }

--- a/tests/L5Sharp.Tests.Core/Common/TagNameTests.cs
+++ b/tests/L5Sharp.Tests.Core/Common/TagNameTests.cs
@@ -100,6 +100,17 @@ namespace L5Sharp.Tests.Core.Common
             
             result.Should().BeFalse();
         }
+        
+        [Test]
+        [Description("GitHub Issue #52: A tag with a bit index reference tag should be qualified")]
+        public void IsQualified_BitIndexAddressing_ShouldBeFalse()
+        {
+            var tagName = new TagName("DintTest.[Offset]");
+            
+            var result = tagName.IsQualified;
+            
+            result.Should().BeTrue();
+        }
 
         [Test]
         public void Root_WhenCalledManyTimes_ShouldBeEfficient()


### PR DESCRIPTION
Updated logic for validating and parsing bit index references in tags, addressing GitHub Issue #52. Modified regex patterns and split options for improved validation. Added new unit tests to ensure correct behavior for tags with bit index references. Incremented version to 4.8.2.