### PR TITLE
Add tests for routine queries and fix parent program resolution

### DIFF
--- a/src/L5Sharp.Core/Components/Routine.cs
+++ b/src/L5Sharp.Core/Components/Routine.cs
@@ -127,9 +127,9 @@ public class Routine : LogixComponent<Routine>
     /// </summary>
     /// <remarks>
     /// This is a navigation helper to allow easily retrieving the parent program for a given routine component.
-    /// This requires an scoped/attached L5X as it traverses the L5X document tree to find the target component. 
+    /// This requires a scoped/attached L5X as it traverses the L5X document tree to find the target component. 
     /// </remarks>
-    public Program? Program => L5X?.Programs.FirstOrDefault(p => p.Routines.Any(r => r.Name.IsEquivalent(Name)));
+    public Program? Program => Element.Ancestors(L5XName.Program).FirstOrDefault()?.Deserialize<Program>();
 
     /// <summary>
     /// Returns a <see cref="LogixContainer{TObject}"/> of <see cref="Rung"/> found in this routine component.

--- a/src/L5Sharp.Core/L5Sharp.Core.csproj
+++ b/src/L5Sharp.Core/L5Sharp.Core.csproj
@@ -8,9 +8,9 @@
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
         <Title>L5Sharp</Title>
         <Authors>Timothy Nunnink</Authors>
-        <Version>4.8.2</Version>
-        <AssemblyVersion>4.8.2</AssemblyVersion>
-        <FileVersion>4.8.2.0</FileVersion>
+        <Version>4.8.3</Version>
+        <AssemblyVersion>4.8.3</AssemblyVersion>
+        <FileVersion>4.8.3.0</FileVersion>
         <Description>A library for intuitively interacting with Rockwell's L5X import/export files.</Description>
         <RepositoryUrl>https://github.com/tnunnink/L5Sharp</RepositoryUrl>
         <PackageTags>csharp allen-bradely l5x logix plc-programming rockwell-automation logix5000</PackageTags>

--- a/tests/L5Sharp.Tests.Core/Components/RoutineTests.cs
+++ b/tests/L5Sharp.Tests.Core/Components/RoutineTests.cs
@@ -105,6 +105,41 @@ public class RoutineTests
         routine.Type.Should().Be(RoutineType.ST);
     }
 
+    #region L5XTest
+
+    [Test]
+    public void ListAllRoutinesInProjectShouldReturnNoneEmptyCollection()
+    {
+        var content = L5X.Load(Known.Test);
+
+        var routines = content.Query<Routine>().ToList();
+
+        routines.Should().NotBeEmpty();
+    }
+    
+    [Test]
+    public void ListAllRoutinesInProjectWithRoutinesOfSameNameShouldReturnNoneEmptyCollection()
+    {
+        var content = L5X.Load(Known.Example);
+
+        var routines = content.Query<Routine>().ToList();
+
+        routines.Should().NotBeEmpty();
+    }
+    
+    [Test]
+    [Description("GitHub Issue #54: All routines should get correct parent program reference")]
+    public void AllRoutinesParentProgramShouldMatchScopeProgramName()
+    {
+        var content = L5X.Load(Known.Example);
+
+        var results = content.Query<Routine>().ToList();
+
+        results.Should().AllSatisfy(r => r.Program?.Name.Should().Be(r.Scope.Program));
+    }
+
+    #endregion
+
     #region FBDTests
 
     [Test]


### PR DESCRIPTION
Added unit tests to verify routine queries return non-empty collections and ensure accurate parent program references for routines. Updated `Routine.Program` logic to use ancestor-based traversal for improved reliability.