### PR TITLE
Add new Duplicate and Replace methods, update version to 5.3.0

### DIFF
--- a/src/L5Sharp.Core/Components/LocalTag.cs
+++ b/src/L5Sharp.Core/Components/LocalTag.cs
@@ -9,7 +9,7 @@ namespace L5Sharp.Core;
 /// </summary>
 /// <remarks>
 /// This class does not add any new functionality but simply overrides the default L5XType to LocalTag. Logix
-/// uses a different element name for tags in an AOI so to match this our L5XTypeAttribute implementation, we are
+/// uses a different element name for tags in an AOI, so to match this our L5XTypeAttribute implementation, we are
 /// deriving a new specific class.
 /// </remarks>
 [L5XType(L5XName.LocalTag)]
@@ -44,15 +44,15 @@ public class LocalTag : Tag, ILogixParsable<LocalTag>
     /// <param name="name">The name of the LocalTag.</param>
     /// <param name="value">The <see cref="LogixData"/> value of the LocalTag.</param>
     /// <param name="description">the optional description of the LocalTag.</param>
-    public LocalTag(string name, LogixData value, string? description = default) : base(L5XName.LocalTag)
+    public LocalTag(string name, LogixData value, string? description = null) : base(L5XName.LocalTag)
     {
         Element.SetAttributeValue(L5XName.Name, name);
         Value = value;
-        SetDescription(description);
+        SetProperty(description, nameof(Description));
     }
 
     /// <summary>
-    /// Returns a new deep cloned instance as the specified <see cref="LogixElement"/> type.
+    /// Returns a new deep-cloned instance as the specified <see cref="LogixElement"/> type.
     /// </summary>
     /// <returns>A new instance of the specified element type with the same property values.</returns>
     public new LocalTag Clone() => new XElement(Serialize()).Deserialize<LocalTag>();
@@ -64,9 +64,9 @@ public class LocalTag : Tag, ILogixParsable<LocalTag>
     /// <returns>A new <see cref="LogixComponent"/> instance that represents the parsed value.</returns>
     /// <remarks>
     /// Internally this uses XElement.Parse along with our <see cref="LogixSerializer"/> to instantiate the concrete instance.
-    /// This means the user can use the <see cref="LogixParser"/> extensions to also parse XML into stongly tyed logix objects.
+    /// This means the user can use the <see cref="LogixParser"/> extensions to also parse XML into strongly typed logix objects.
     /// Also note that since this uses internal XElement and casts the type, this method can throw exceptions for invalid
-    /// XML or XML that is parsed to an different type thatn the one specified here.
+    /// XML or XML that is parsed to a different type than the one specified here.
     /// </remarks>
     public new static LocalTag Parse(string value)
     {
@@ -76,23 +76,23 @@ public class LocalTag : Tag, ILogixParsable<LocalTag>
 
     /// <summary>
     /// Attempts to parse the provided string and returned the strongly typed component object.
-    /// If unsuccesful, then this method returns <c>null</c>.
+    /// If unsuccessful, then this method returns <c>null</c>.
     /// </summary>
     /// <param name="value">The XML string value to parse.</param>
     /// <returns>A new <see cref="LogixComponent"/> instance that represents the parsed value if successful, otherwise, <c>null</c>.</returns>
     /// <remarks>
     /// Internally this uses XElement.Parse along with our <see cref="LogixSerializer"/> to instantiate the concrete instance.
-    /// This means the user can use the <see cref="LogixParser"/> extensions to also parse XML into stongly tyed logix objects.
+    /// This means the user can use the <see cref="LogixParser"/> extensions to also parse XML into strongly typed logix objects.
     /// Note that this method will just return null if any exception is caught. This could be for invalid XML formats
     /// of invalid type casts.
     /// </remarks>
     public new static LocalTag? TryParse(string? value)
     {
         if (value is null || value.IsEmpty()) //this satisfies the .NET 2.0 compiler warnings about null.
-            return default;
+            return null;
 
         var trimmed = value.Trim();
-        if (trimmed.Length == 0 || trimmed[0] != '<') return default;
+        if (trimmed.Length == 0 || trimmed[0] != '<') return null;
 
         try
         {
@@ -101,7 +101,7 @@ public class LocalTag : Tag, ILogixParsable<LocalTag>
         }
         catch (Exception)
         {
-            return default;
+            return null;
         }
     }
 }

--- a/src/L5Sharp.Core/Components/Tag.cs
+++ b/src/L5Sharp.Core/Components/Tag.cs
@@ -84,7 +84,7 @@ public class Tag : LogixComponent<Tag>
     {
         Element.SetAttributeValue(L5XName.Name, name);
         Value = value;
-        SetDescription(description);
+        SetProperty(description, nameof(Description));
     }
 
     /// <summary>
@@ -102,7 +102,7 @@ public class Tag : LogixComponent<Tag>
     {
         Element.SetAttributeValue(L5XName.Name, name);
         Value = LogixData.Create(dataType);
-        SetDescription(description);
+        SetProperty(description, nameof(Description));
     }
 
     /// <summary>
@@ -890,7 +890,7 @@ public class Tag : LogixComponent<Tag>
     {
         //We can use this tag name to determine which parent module tag to retrieve.
         var tagName = GetTagName();
-        var parts = tagName.Split(':', StringSplitOptions.RemoveEmptyEntries).ToArray();
+        var parts = tagName.Split(':', StringSplitOptions.RemoveEmptyEntries);
 
         //We have to have all 3 parts (module name, I/O suffix, and slot number) to find the correct member.
         //If not, then we will default to a virtual member with a no action getter and setter;

--- a/src/L5Sharp.Core/Elements/DataTypeMember.cs
+++ b/src/L5Sharp.Core/Elements/DataTypeMember.cs
@@ -52,7 +52,7 @@ public class DataTypeMember : LogixObject<DataTypeMember>
     public string? Description
     {
         get => GetProperty<string>();
-        set => SetDescription(value);
+        set => SetProperty(value);
     }
 
     /// <summary>

--- a/src/L5Sharp.Core/Elements/Parameter.cs
+++ b/src/L5Sharp.Core/Elements/Parameter.cs
@@ -56,7 +56,7 @@ public class Parameter : LogixObject<Parameter>
     /// This constructor if meant to create simple atomic Input/Output parameters which can be used as members
     /// of the complex tag data structure for an AOI component.
     /// </remarks>
-    public Parameter(string name, AtomicData value, TagUsage? usage = default) : this()
+    public Parameter(string name, AtomicData value, TagUsage? usage = null) : this()
     {
         Element.SetAttributeValue(L5XName.Name, name);
         DataType = value.Name;
@@ -82,7 +82,7 @@ public class Parameter : LogixObject<Parameter>
     public string? Description
     {
         get => GetProperty<string>();
-        set => SetDescription(value);
+        set => SetProperty(value);
     }
 
     /// <summary>
@@ -158,7 +158,7 @@ public class Parameter : LogixObject<Parameter>
     /// </summary>
     /// <value>
     /// A <see cref="TagUsage"/> option representing the <c>Parameter</c> scope.
-    /// Default for AoiBlock is <see cref="TagUsage.Input"/>. Only valid options for AoiBlock are Input, Output,
+    /// Default for AoiBlock is <see cref="TagUsage.Input"/>. The only valid options for AoiBlock are Input, Output,
     /// and InOut.
     /// </value>
     public TagUsage Usage
@@ -168,7 +168,7 @@ public class Parameter : LogixObject<Parameter>
     }
 
     /// <summary>
-    /// Indicates whether the <c>Parameter</c> is required form the instruction code clock.
+    /// Indicates whether the <c>Parameter</c> is required from the instruction code clock.
     /// </summary>
     /// <value>
     /// <c>true</c> if the <c>Parameter</c> is required; otherwise, false. Default is <c>false</c>.</value>
@@ -212,7 +212,7 @@ public class Parameter : LogixObject<Parameter>
     /// Indicates whether the <c>Parameter</c> is a constant.
     /// </summary>
     /// <value><c>true</c> if the <c>Parameter</c> is constant; otherwise, <c>false</c>.</value>
-    /// <remarks>Only value type tags have the ability to be set as a constant. Default is <c>false</c>.</remarks>
+    /// <remarks>Only value type tags can be set as a constant. Default is <c>false</c>.</remarks>
     public bool? Constant
     {
         get => GetValue<bool>();
@@ -224,9 +224,9 @@ public class Parameter : LogixObject<Parameter>
     /// </summary>
     /// <param name="tagName">The name of the tag.</param>
     /// <returns>A <see cref="Tag"/> instance with the specified name and value populated using this parameter's configuration.</returns>
-    /// <exception cref="InvalidOperationException"><see cref="DataType"/> is null or emprty.</exception>
+    /// <exception cref="InvalidOperationException"><see cref="DataType"/> is null or empty.</exception>
     /// <remarks>
-    /// This is a helper to allow us to generate default tag instance from a parameter element. This will internally
+    /// This is a helper to allow us to generate a default tag instance from a parameter element. This will internally
     /// generate a default <see cref="LogixData"/> instance using the configured data typ name of the parameter.
     /// </remarks>
     public Tag ToTag(string tagName)
@@ -248,10 +248,10 @@ public class Parameter : LogixObject<Parameter>
     /// is not configured as Input or Output.</exception>
     /// <returns>A <see cref="Member"/> instance with the name and default value of the current parameter.</returns>
     /// <remarks>
-    /// This is helper to allow us to generate default tag members from a given parameter, so that we
+    /// This is a helper to allow us to generate default tag members from a given parameter so that we
     /// can easily build up an in memory instance of an AOI tag component. Note that this method is intended to only be
-    /// called on Input or Output parameters which Logix requires to be atomic type parameters. these are the only parameter
-    /// types that are available on a AOI tag instance.
+    /// called on Input or Output parameters, which Logix requires to be atomic type parameters.
+    /// These are the only parameter types that are available on an AOI tag instance.
     /// </remarks>
     public Member ToMember()
     {

--- a/src/L5Sharp.Core/Elements/Pen.cs
+++ b/src/L5Sharp.Core/Elements/Pen.cs
@@ -58,7 +58,7 @@ public class Pen : LogixObject
     public string? Description
     {
         get => GetProperty<string>();
-        set => SetDescription(value);
+        set => SetProperty(value);
     }
 
     /// <summary>

--- a/src/L5Sharp.Core/Elements/Sheet.cs
+++ b/src/L5Sharp.Core/Elements/Sheet.cs
@@ -15,7 +15,7 @@ namespace L5Sharp.Core;
 ///     • The sheets in the routine appear in order in the export file.
 ///         Each sheet section contains all the drawing elements and wires for that sheet. <br/>
 ///     • On import, sheet numbers are assigned based on order in the file, not on the number attribute on the sheet.<br/>
-///     • The sheet name is stored as description on the sheet.<br/>
+///     • The sheet name is stored as a description on the sheet.<br/>
 ///     • Input references, blocks, output references, special drawing elements,
 ///         and wires are contained within the sheet. On export, the elements
 ///         appear in the order shown. On import in the L5K format, elements can
@@ -24,7 +24,7 @@ namespace L5Sharp.Core;
 ///     • Wire and feedback wire statements must appear after all the other
 ///         components.<br/>
 ///     • Be careful when copying and pasting function block components
-///         within an import/export file. Each component within a sheet must
+///         within an import/export file. Each component within a sheet must-
 ///         have a unique id number within that sheet.<br/>
 /// </para>
 /// </remarks>
@@ -75,7 +75,7 @@ public class Sheet : Diagram
     public string? Description
     {
         get => GetProperty<string>();
-        set => SetDescription(value);
+        set => SetProperty(value);
     }
 
     /// <summary>

--- a/src/L5Sharp.Core/L5Sharp.Core.csproj
+++ b/src/L5Sharp.Core/L5Sharp.Core.csproj
@@ -8,9 +8,9 @@
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
         <Title>L5Sharp</Title>
         <Authors>Timothy Nunnink</Authors>
-        <Version>5.2.0</Version>
-        <AssemblyVersion>5.2.0</AssemblyVersion>
-        <FileVersion>5.2.0.0</FileVersion>
+        <Version>5.3.0</Version>
+        <AssemblyVersion>5.3.0</AssemblyVersion>
+        <FileVersion>5.3.0.0</FileVersion>
         <Description>A library for intuitively interacting with Rockwell's L5X import/export files.</Description>
         <RepositoryUrl>https://github.com/tnunnink/L5Sharp</RepositoryUrl>
         <PackageTags>csharp allen-bradely l5x logix plc-programming rockwell-automation logix5000</PackageTags>

--- a/src/L5Sharp.Core/LogixContainer.cs
+++ b/src/L5Sharp.Core/LogixContainer.cs
@@ -309,7 +309,7 @@ public sealed class LogixContainer<TObject> : LogixElement, IList<TObject>, ICol
     /// <inheritdoc />
     public IEnumerator<TObject> GetEnumerator() =>
         Element.Elements(L5XType).Select(e => e.Deserialize<TObject>()).GetEnumerator();
-    
+
     void ICollection.CopyTo(Array array, int index)
     {
         var source = Element.Elements(L5XType).Select(e => e.Deserialize<TObject>()).ToArray();

--- a/src/L5Sharp.Core/LogixElement.cs
+++ b/src/L5Sharp.Core/LogixElement.cs
@@ -689,35 +689,6 @@ public abstract class LogixElement : ILogixSerializable
     }
 
     /// <summary>
-    /// Adds, removes, or updates the common logix description child element on the current underlying element object.
-    /// If null, it will remove the child element. If not null, will either add as the first child element or replace the
-    /// existing child element.
-    /// </summary>
-    /// <param name="value">The description value to set.</param>
-    /// <remarks>
-    /// This is a specialized helper to make setting the description value as concise as possible for derived
-    /// classes. Many logix elements will have a description element.
-    /// </remarks>
-    protected void SetDescription(string? value = null)
-    {
-        if (value is null)
-        {
-            Element.Element(L5XName.Description)?.Remove();
-            return;
-        }
-
-        var description = Element.Element(L5XName.Description);
-
-        if (description is null)
-        {
-            Element.AddFirst(new XElement(L5XName.Description, new XCData(value)));
-            return;
-        }
-
-        description.ReplaceWith(new XElement(L5XName.Description, new XCData(value)));
-    }
-
-    /// <summary>
     /// Add or updates the child data element with the data of the provided <see cref="LogixData"/> object.
     /// </summary>
     /// <param name="data">The <see cref="LogixData"/> data to update.</param>

--- a/src/L5Sharp.Core/LogixObject.cs
+++ b/src/L5Sharp.Core/LogixObject.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Xml.Linq;
 
 namespace L5Sharp.Core;
@@ -7,8 +8,8 @@ namespace L5Sharp.Core;
 /// <summary>
 /// A class implementing <see cref="LogixElement"/> that adds common properties and methods shared by most elements or
 /// components. Features include the <see cref="Scope"/> to identify where in the document they exist,
-/// and methods <see cref="AddBefore"/>, <see cref="AddBefore"/>, <see cref="Remove"/>, and <see cref="Replace"/>
-/// which allow easy interface to mutate the object or collection of objects.
+/// and methods <see cref="AddBefore"/>, <see cref="AddBefore"/>, <see cref="Remove"/>, and
+/// <see cref="Replace(L5Sharp.Core.LogixObject)"/> which allow easy interface to mutate the object or collection of objects.
 /// </summary>
 public abstract class LogixObject : LogixElement
 {
@@ -193,6 +194,25 @@ public abstract class LogixObject : LogixElement
         }
 
         Element.ReplaceWith(element.Serialize());
+    }
+
+    /// <summary>
+    /// Replaces occurrences of a specified string within the properties of the underlying XML element.
+    /// </summary>
+    /// <param name="find">The string to find within the element properties.</param>
+    /// <param name="replace">The string to replace the found occurrences with.</param>
+    /// <param name="properties">An optional array of property names that specify the scope of the replacement operation.
+    /// If no property is specified, then this method will operate on every immediate and nested property in the object.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="find"/> or <paramref name="replace"/> is <c>null</c>.</exception>
+    public void Replace(string find, string replace, string[]? properties = null)
+    {
+        if (find is null)
+            throw new ArgumentNullException(nameof(find));
+
+        if (replace is null)
+            throw new ArgumentNullException(nameof(replace));
+
+        Element.FindAndReplace(find, replace, properties ?? []);
     }
 }
 

--- a/tests/L5Sharp.Tests.Core/Components/ProgramTests.Duplicate_ValidConfig_ShouldBeVerified.verified.txt
+++ b/tests/L5Sharp.Tests.Core/Components/ProgramTests.Duplicate_ValidConfig_ShouldBeVerified.verified.txt
@@ -1,0 +1,342 @@
+﻿<Program Name="DuplicateProgram" TestEdits="false" MainRoutineName="Main" Disabled="false" UseAsFolder="false">
+  <Description><![CDATA[This is my new program]]></Description>
+  <Tags>
+    <Tag Name="Action_000" TagType="Base" DataType="SFC_ACTION" Constant="false" ExternalAccess="Read/Write">
+      <Data Format="L5K"><![CDATA[[2097152,0,0,0]]]></Data>
+      <Data Format="Decorated">
+        <Structure DataType="SFC_ACTION">
+          <DataValueMember Name="Status" DataType="DINT" Radix="Hex" Value="16#0020_0000" />
+          <DataValueMember Name="A" DataType="BOOL" Value="0" />
+          <DataValueMember Name="Q" DataType="BOOL" Value="0" />
+          <DataValueMember Name="PauseTimer" DataType="BOOL" Value="1" />
+          <DataValueMember Name="PRE" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="T" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="Count" DataType="DINT" Radix="Decimal" Value="0" />
+        </Structure>
+      </Data>
+    </Tag>
+    <Tag Name="BufferTag" TagType="Base" DataType="BOOL" Radix="Decimal" Constant="false" ExternalAccess="Read/Write">
+      <Data Format="L5K"><![CDATA[0]]></Data>
+      <Data Format="Decorated">
+        <DataValue DataType="BOOL" Radix="Decimal" Value="0" />
+      </Data>
+    </Tag>
+    <Tag Name="Channel" TagType="Base" DataType="DINT" Radix="Decimal" Constant="false" ExternalAccess="Read/Write">
+      <Data Format="L5K"><![CDATA[0]]></Data>
+      <Data Format="Decorated">
+        <DataValue DataType="DINT" Radix="Decimal" Value="0" />
+      </Data>
+    </Tag>
+    <Tag Name="InputParameter" TagType="Base" DataType="DINT" Radix="Decimal" Constant="false" ExternalAccess="Read/Write">
+      <Data Format="L5K"><![CDATA[0]]></Data>
+      <Data Format="Decorated">
+        <DataValue DataType="DINT" Radix="Decimal" Value="0" />
+      </Data>
+    </Tag>
+    <Tag Name="OutputParameter" TagType="Base" DataType="DINT" Radix="Decimal" Constant="false" ExternalAccess="Read/Write">
+      <Data Format="L5K"><![CDATA[0]]></Data>
+      <Data Format="Decorated">
+        <DataValue DataType="DINT" Radix="Decimal" Value="0" />
+      </Data>
+    </Tag>
+    <Tag Name="Step_000" TagType="Base" DataType="SFC_STEP" Constant="false" ExternalAccess="Read/Write">
+      <Data Format="L5K"><![CDATA[[2097152,0,0,0,0,0,0]]]></Data>
+      <Data Format="Decorated">
+        <Structure DataType="SFC_STEP">
+          <DataValueMember Name="Status" DataType="DINT" Radix="Hex" Value="16#0020_0000" />
+          <DataValueMember Name="X" DataType="BOOL" Value="0" />
+          <DataValueMember Name="FS" DataType="BOOL" Value="0" />
+          <DataValueMember Name="SA" DataType="BOOL" Value="0" />
+          <DataValueMember Name="LS" DataType="BOOL" Value="0" />
+          <DataValueMember Name="DN" DataType="BOOL" Value="0" />
+          <DataValueMember Name="OV" DataType="BOOL" Value="0" />
+          <DataValueMember Name="AlarmEn" DataType="BOOL" Value="0" />
+          <DataValueMember Name="AlarmLow" DataType="BOOL" Value="0" />
+          <DataValueMember Name="AlarmHigh" DataType="BOOL" Value="0" />
+          <DataValueMember Name="Reset" DataType="BOOL" Value="0" />
+          <DataValueMember Name="PauseTimer" DataType="BOOL" Value="1" />
+          <DataValueMember Name="PRE" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="T" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="TMax" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="Count" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="LimitLow" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="LimitHigh" DataType="DINT" Radix="Decimal" Value="0" />
+        </Structure>
+      </Data>
+    </Tag>
+    <Tag Name="Step_001" TagType="Base" DataType="SFC_STEP" Constant="false" ExternalAccess="Read/Write">
+      <Data Format="L5K"><![CDATA[[2097152,0,0,0,0,0,0]]]></Data>
+      <Data Format="Decorated">
+        <Structure DataType="SFC_STEP">
+          <DataValueMember Name="Status" DataType="DINT" Radix="Hex" Value="16#0020_0000" />
+          <DataValueMember Name="X" DataType="BOOL" Value="0" />
+          <DataValueMember Name="FS" DataType="BOOL" Value="0" />
+          <DataValueMember Name="SA" DataType="BOOL" Value="0" />
+          <DataValueMember Name="LS" DataType="BOOL" Value="0" />
+          <DataValueMember Name="DN" DataType="BOOL" Value="0" />
+          <DataValueMember Name="OV" DataType="BOOL" Value="0" />
+          <DataValueMember Name="AlarmEn" DataType="BOOL" Value="0" />
+          <DataValueMember Name="AlarmLow" DataType="BOOL" Value="0" />
+          <DataValueMember Name="AlarmHigh" DataType="BOOL" Value="0" />
+          <DataValueMember Name="Reset" DataType="BOOL" Value="0" />
+          <DataValueMember Name="PauseTimer" DataType="BOOL" Value="1" />
+          <DataValueMember Name="PRE" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="T" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="TMax" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="Count" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="LimitLow" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="LimitHigh" DataType="DINT" Radix="Decimal" Value="0" />
+        </Structure>
+      </Data>
+    </Tag>
+    <Tag Name="Step_002" TagType="Base" DataType="SFC_STEP" Constant="false" ExternalAccess="Read/Write">
+      <Data Format="L5K"><![CDATA[[2097152,0,0,0,0,0,0]]]></Data>
+      <Data Format="Decorated">
+        <Structure DataType="SFC_STEP">
+          <DataValueMember Name="Status" DataType="DINT" Radix="Hex" Value="16#0020_0000" />
+          <DataValueMember Name="X" DataType="BOOL" Value="0" />
+          <DataValueMember Name="FS" DataType="BOOL" Value="0" />
+          <DataValueMember Name="SA" DataType="BOOL" Value="0" />
+          <DataValueMember Name="LS" DataType="BOOL" Value="0" />
+          <DataValueMember Name="DN" DataType="BOOL" Value="0" />
+          <DataValueMember Name="OV" DataType="BOOL" Value="0" />
+          <DataValueMember Name="AlarmEn" DataType="BOOL" Value="0" />
+          <DataValueMember Name="AlarmLow" DataType="BOOL" Value="0" />
+          <DataValueMember Name="AlarmHigh" DataType="BOOL" Value="0" />
+          <DataValueMember Name="Reset" DataType="BOOL" Value="0" />
+          <DataValueMember Name="PauseTimer" DataType="BOOL" Value="1" />
+          <DataValueMember Name="PRE" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="T" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="TMax" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="Count" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="LimitLow" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="LimitHigh" DataType="DINT" Radix="Decimal" Value="0" />
+        </Structure>
+      </Data>
+    </Tag>
+    <Tag Name="Step_003" TagType="Base" DataType="SFC_STEP" Constant="false" ExternalAccess="Read/Write">
+      <Data Format="L5K"><![CDATA[[2097152,0,0,0,0,0,0]]]></Data>
+      <Data Format="Decorated">
+        <Structure DataType="SFC_STEP">
+          <DataValueMember Name="Status" DataType="DINT" Radix="Hex" Value="16#0020_0000" />
+          <DataValueMember Name="X" DataType="BOOL" Value="0" />
+          <DataValueMember Name="FS" DataType="BOOL" Value="0" />
+          <DataValueMember Name="SA" DataType="BOOL" Value="0" />
+          <DataValueMember Name="LS" DataType="BOOL" Value="0" />
+          <DataValueMember Name="DN" DataType="BOOL" Value="0" />
+          <DataValueMember Name="OV" DataType="BOOL" Value="0" />
+          <DataValueMember Name="AlarmEn" DataType="BOOL" Value="0" />
+          <DataValueMember Name="AlarmLow" DataType="BOOL" Value="0" />
+          <DataValueMember Name="AlarmHigh" DataType="BOOL" Value="0" />
+          <DataValueMember Name="Reset" DataType="BOOL" Value="0" />
+          <DataValueMember Name="PauseTimer" DataType="BOOL" Value="1" />
+          <DataValueMember Name="PRE" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="T" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="TMax" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="Count" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="LimitLow" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="LimitHigh" DataType="DINT" Radix="Decimal" Value="0" />
+        </Structure>
+      </Data>
+    </Tag>
+    <Tag Name="Step_004" TagType="Base" DataType="SFC_STEP" Constant="false" ExternalAccess="Read/Write">
+      <Data Format="L5K"><![CDATA[[2097152,0,0,0,0,0,0]]]></Data>
+      <Data Format="Decorated">
+        <Structure DataType="SFC_STEP">
+          <DataValueMember Name="Status" DataType="DINT" Radix="Hex" Value="16#0020_0000" />
+          <DataValueMember Name="X" DataType="BOOL" Value="0" />
+          <DataValueMember Name="FS" DataType="BOOL" Value="0" />
+          <DataValueMember Name="SA" DataType="BOOL" Value="0" />
+          <DataValueMember Name="LS" DataType="BOOL" Value="0" />
+          <DataValueMember Name="DN" DataType="BOOL" Value="0" />
+          <DataValueMember Name="OV" DataType="BOOL" Value="0" />
+          <DataValueMember Name="AlarmEn" DataType="BOOL" Value="0" />
+          <DataValueMember Name="AlarmLow" DataType="BOOL" Value="0" />
+          <DataValueMember Name="AlarmHigh" DataType="BOOL" Value="0" />
+          <DataValueMember Name="Reset" DataType="BOOL" Value="0" />
+          <DataValueMember Name="PauseTimer" DataType="BOOL" Value="1" />
+          <DataValueMember Name="PRE" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="T" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="TMax" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="Count" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="LimitLow" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="LimitHigh" DataType="DINT" Radix="Decimal" Value="0" />
+        </Structure>
+      </Data>
+    </Tag>
+    <Tag Name="Stop_000" TagType="Base" DataType="SFC_STOP" Constant="false" ExternalAccess="Read/Write">
+      <Data Format="L5K"><![CDATA[[0,0,0,0,0]]]></Data>
+      <Data Format="Decorated">
+        <Structure DataType="SFC_STOP">
+          <DataValueMember Name="Status" DataType="DINT" Radix="Hex" Value="16#0000_0000" />
+          <DataValueMember Name="X" DataType="BOOL" Value="0" />
+          <DataValueMember Name="Reset" DataType="BOOL" Value="0" />
+          <DataValueMember Name="Count" DataType="DINT" Radix="Decimal" Value="0" />
+        </Structure>
+      </Data>
+    </Tag>
+    <Tag Name="Temp" TagType="Base" DataType="SERIAL_PORT_CONTROL" Constant="false" ExternalAccess="Read/Write">
+      <Data Format="L5K"><![CDATA[[0,0,12,0]]]></Data>
+      <Data Format="Decorated">
+        <Structure DataType="SERIAL_PORT_CONTROL">
+          <DataValueMember Name="LEN" DataType="DINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="POS" DataType="DINT" Radix="Decimal" Value="12" />
+          <DataValueMember Name="ERROR" DataType="DINT" Radix="Hex" Value="16#0000_0000" />
+          <DataValueMember Name="EN" DataType="BOOL" Value="0" />
+          <DataValueMember Name="EU" DataType="BOOL" Value="0" />
+          <DataValueMember Name="DN" DataType="BOOL" Value="0" />
+          <DataValueMember Name="EM" DataType="BOOL" Value="0" />
+          <DataValueMember Name="ER" DataType="BOOL" Value="0" />
+          <DataValueMember Name="UL" DataType="BOOL" Value="0" />
+          <DataValueMember Name="RN" DataType="BOOL" Value="0" />
+          <DataValueMember Name="FD" DataType="BOOL" Value="0" />
+        </Structure>
+      </Data>
+    </Tag>
+    <Tag Name="TempSimpleTag" TagType="Base" DataType="SimpleType" Constant="false" ExternalAccess="Read/Write">
+      <Data Format="L5K"><![CDATA[[0,0,0,0,0,0.00000000e+000]]]></Data>
+      <Data Format="Decorated">
+        <Structure DataType="SimpleType">
+          <DataValueMember Name="BoolMember" DataType="BOOL" Value="0" />
+          <DataValueMember Name="SintMember" DataType="SINT" Radix="Hex" Value="16#00" />
+          <DataValueMember Name="IntMember" DataType="INT" Radix="Octal" Value="8#000_000" />
+          <DataValueMember Name="DintMember" DataType="DINT" Radix="ASCII" Value="'$00$00$00$00'" />
+          <DataValueMember Name="LintMember" DataType="LINT" Radix="Decimal" Value="0" />
+          <DataValueMember Name="RealMember" DataType="REAL" Radix="Float" Value="0.0" />
+        </Structure>
+      </Data>
+    </Tag>
+    <Tag Name="Tran_000" TagType="Base" DataType="BOOL" Radix="Decimal" Constant="false" ExternalAccess="Read/Write">
+      <Data Format="L5K"><![CDATA[0]]></Data>
+      <Data Format="Decorated">
+        <DataValue DataType="BOOL" Radix="Decimal" Value="0" />
+      </Data>
+    </Tag>
+    <Tag Name="Tran_001" TagType="Base" DataType="BOOL" Radix="Decimal" Constant="false" ExternalAccess="Read/Write">
+      <Data Format="L5K"><![CDATA[0]]></Data>
+      <Data Format="Decorated">
+        <DataValue DataType="BOOL" Radix="Decimal" Value="0" />
+      </Data>
+    </Tag>
+    <Tag Name="Tran_002" TagType="Base" DataType="BOOL" Radix="Decimal" Constant="false" ExternalAccess="Read/Write">
+      <Data Format="L5K"><![CDATA[0]]></Data>
+      <Data Format="Decorated">
+        <DataValue DataType="BOOL" Radix="Decimal" Value="0" />
+      </Data>
+    </Tag>
+  </Tags>
+  <Routines>
+    <Routine Name="FBD" Type="FBD">
+      <FBDContent SheetSize="B - 11 x 17 in" SheetOrientation="Landscape">
+        <Sheet Number="1">
+          <IRef ID="0" X="140" Y="180" Operand="SimpleBool" HideDesc="false" />
+          <ORef ID="1" X="500" Y="200" Operand="TempComplexTag.SimpleMember.BoolMember" HideDesc="false" />
+          <Function Type="BNOT__F" ID="2" X="140" Y="260" />
+          <Function Type="BAND__F" ID="3" X="260" Y="200" />
+          <Wire FromID="0" ToID="2" ToParam="In" />
+          <Wire FromID="0" ToID="3" ToParam="In1" />
+          <Wire FromID="2" FromParam="Out" ToID="3" ToParam="In2" />
+          <Wire FromID="3" FromParam="Out" ToID="1" />
+          <TextBox ID="4" X="60" Y="100" Width="0">
+            <Text><![CDATA[Temp]]></Text>
+          </TextBox>
+        </Sheet>
+      </FBDContent>
+    </Routine>
+    <Routine Name="Main" Type="RLL">
+      <RLLContent>
+        <Rung Number="0" Type="N">
+          <Text><![CDATA[TON(TempTimer,?,?);]]></Text>
+        </Rung>
+        <Rung Number="1" Type="N">
+          <Text><![CDATA[MOV(16#20,SimpleSint);]]></Text>
+        </Rung>
+        <Rung Number="2" Type="N">
+          <Text><![CDATA[aoi_Temp(aoiTempInstance,TempSimpleTag,SimpleInt,RealArray,0);]]></Text>
+        </Rung>
+        <Rung Number="3" Type="N">
+          <Text><![CDATA[[XIC(SimpleBool) ,XIC(SimpleBool) ][OTE(SimpleBool) ,OTU(SimpleBool) ];]]></Text>
+        </Rung>
+        <Rung Number="4" Type="N">
+          <Text><![CDATA[OTE(TempComplexTag.SimpleMember.BoolMember);]]></Text>
+        </Rung>
+        <Rung Number="5" Type="N">
+          <Text><![CDATA[MOV(SimpleSint,AsciiTag);]]></Text>
+        </Rung>
+        <Rung Number="6" Type="N">
+          <Text><![CDATA[XIC(FlexIO:3:I.Pt01.Data)OTE(BufferTag);]]></Text>
+        </Rung>
+        <Rung Number="7" Type="N">
+          <Text><![CDATA[JSR(FBD,1,InputParameter,OutputParameter);]]></Text>
+        </Rung>
+        <Rung Number="8" Type="N">
+          <Text><![CDATA[GRT(SimpleInt,100)OTE(SimpleArray[4].0);]]></Text>
+        </Rung>
+        <Rung Number="9" Type="N">
+          <Text><![CDATA[GRT(SimpleInt,400)XIO(MultiDimensionalArray[1,3].3)CMP(ATN(_Temp) > 1.0)[TON(TimerArray[0],?,?) ,OTU(TempComplexTag.SimpleMember.BoolMember) ];]]></Text>
+        </Rung>
+        <Rung Number="10" Type="N">
+          <Text><![CDATA[OTE(SimpleDint.[TempSimpleTag.IntMember]);]]></Text>
+        </Rung>
+      </RLLContent>
+    </Routine>
+    <Routine Name="SFC" Type="SFC">
+      <SFCContent SheetSize="Letter - 8.5 x 11 in" SheetOrientation="Landscape" StepName="Step" TransitionName="Tran" ActionName="Action" StopName="Stop">
+        <Step ID="0" X="200" Y="100" Operand="Step_001" HideDesc="false" DescX="240" DescY="80" DescWidth="0" InitialStep="true" PresetUsesExpr="false" LimitHighUsesExpr="false" LimitLowUsesExpr="false" ShowActions="true">
+          <Action ID="1" Operand="Action_000" Qualifier="NonStored" IsBoolean="false" PresetUsesExpr="false">
+            <Body>
+              <STContent>
+                <Line Number="0"><![CDATA[]]></Line>
+              </STContent>
+            </Body>
+          </Action>
+        </Step>
+        <Step ID="2" X="700" Y="120" Operand="Step_002" HideDesc="false" DescX="740" DescY="100" DescWidth="0" InitialStep="false" PresetUsesExpr="false" LimitHighUsesExpr="false" LimitLowUsesExpr="false" ShowActions="true" />
+        <Step ID="3" X="420" Y="380" Operand="Step_003" HideDesc="false" DescX="460" DescY="360" DescWidth="0" InitialStep="false" PresetUsesExpr="false" LimitHighUsesExpr="false" LimitLowUsesExpr="false" ShowActions="true" />
+        <Step ID="4" X="520" Y="380" Operand="Step_004" HideDesc="false" DescX="560" DescY="360" DescWidth="0" InitialStep="false" PresetUsesExpr="false" LimitHighUsesExpr="false" LimitLowUsesExpr="false" ShowActions="true" />
+        <Transition ID="5" X="200" Y="180" Operand="Tran_001" HideDesc="false" DescX="260" DescY="160" DescWidth="0">
+          <Condition>
+            <STContent>
+              <Line Number="0"><![CDATA[SimpleBool := TempComplexTag.SimpleMember.BoolMember;]]></Line>
+            </STContent>
+          </Condition>
+        </Transition>
+        <Transition ID="6" X="700" Y="200" Operand="Tran_002" HideDesc="false" DescX="760" DescY="180" DescWidth="0">
+          <Condition>
+            <STContent>
+              <Line Number="0"><![CDATA[]]></Line>
+            </STContent>
+          </Condition>
+        </Transition>
+        <Branch ID="7" Y="278" BranchType="Simultaneous" BranchFlow="Diverge">
+          <Leg ID="8" />
+          <Leg ID="9" />
+        </Branch>
+        <Branch ID="10" Y="300" BranchType="Selection" BranchFlow="Converge">
+          <Leg ID="11" />
+          <Leg ID="12" />
+        </Branch>
+        <Branch ID="13" Y="340" BranchType="Simultaneous" BranchFlow="Diverge">
+          <Leg ID="14" />
+          <Leg ID="15" />
+        </Branch>
+        <Stop ID="16" X="760" Y="380" Operand="Stop_000" HideDesc="false" DescX="840" DescY="360" DescWidth="0" />
+        <DirectedLink FromID="0" ToID="5" Show="true" />
+        <DirectedLink FromID="2" ToID="6" Show="true" />
+        <DirectedLink FromID="5" ToID="11" Show="true" />
+        <DirectedLink FromID="6" ToID="7" Show="true" />
+        <DirectedLink FromID="8" ToID="12" Show="true" />
+        <DirectedLink FromID="9" ToID="16" Show="true" />
+        <DirectedLink FromID="14" ToID="4" Show="true" />
+        <DirectedLink FromID="15" ToID="3" Show="true" />
+      </SFCContent>
+    </Routine>
+    <Routine Name="ST" Type="ST">
+      <STContent>
+        <Line Number="0"><![CDATA[SimpleBool := TempComplexTag.SimpleMember.BoolMember;]]></Line>
+        <Line Number="1"><![CDATA[]]></Line>
+        <Line Number="2"><![CDATA[]]></Line>
+      </STContent>
+    </Routine>
+  </Routines>
+</Program>

--- a/tests/L5Sharp.Tests.Core/Components/ProgramTests.cs
+++ b/tests/L5Sharp.Tests.Core/Components/ProgramTests.cs
@@ -73,7 +73,7 @@ public class ProgramTests
 
         program.Tags.Should().HaveCount(1);
     }
-    
+
     [Test]
     public Task AddTag_ValidTag_ShouldBeVerified()
     {
@@ -93,7 +93,7 @@ public class ProgramTests
 
         program.Routines.Should().HaveCount(1);
     }
-    
+
     [Test]
     public Task AddRoutine_ValidRoutine_ShouldBeVerified()
     {
@@ -118,12 +118,28 @@ public class ProgramTests
             MainRoutineName = "Main",
             FaultRoutineName = "Fault",
             UseAsFolder = true,
-            Tags = new LogixContainer<Tag> { new() { Name = "Test", Value = true } },
-            Routines = new LogixContainer<Routine>()
+            Tags = [new Tag { Name = "Test", Value = true }],
+            Routines = []
         };
 
         var xml = program.Serialize().ToString();
 
         return Verify(xml);
+    }
+
+    [Test]
+    public Task Duplicate_ValidConfig_ShouldBeVerified()
+    {
+        var content = L5X.Load(Known.Test);
+        var program = content.Get<Program>("MainProgram");
+
+        var duplicate = program.Duplicate(p =>
+        {
+            p.Name = "DuplicateProgram";
+            p.Description = "This is my new program";
+            p.Replace("Test", "Temp");
+        });
+
+        return Verify(duplicate.Serialize().ToString());
     }
 }

--- a/tests/L5Sharp.Tests.Core/Components/TagTests.Duplicate_ValidConfig_ShouldBeVerified.verified.txt
+++ b/tests/L5Sharp.Tests.Core/Components/TagTests.Duplicate_ValidConfig_ShouldBeVerified.verified.txt
@@ -1,0 +1,14 @@
+﻿<Tag Name="NewSimpleTag" TagType="Base" DataType="SimpleType" Constant="false" ExternalAccess="Read Only">
+  <Description><![CDATA[This is an updated tag]]></Description>
+  <Data Format="L5K"><![CDATA[[0,0,14,1,0,0.00000000e+000]]]></Data>
+  <Data Format="Decorated">
+    <Structure DataType="SimpleType">
+      <DataValueMember Name="BoolMember" DataType="BOOL" Value="0" />
+      <DataValueMember Name="SintMember" DataType="SINT" Radix="Hex" Value="16#00" />
+      <DataValueMember Name="IntMember" DataType="INT" Radix="Octal" Value="8#000_016" />
+      <DataValueMember Name="DintMember" DataType="DINT" Radix="ASCII" Value="'$00$00$DB$8B'" />
+      <DataValueMember Name="LintMember" DataType="LINT" Radix="Decimal" Value="0" />
+      <DataValueMember Name="RealMember" DataType="REAL" Radix="Float" Value="345.6" />
+    </Structure>
+  </Data>
+</Tag>

--- a/tests/L5Sharp.Tests.Core/Components/TagTests.cs
+++ b/tests/L5Sharp.Tests.Core/Components/TagTests.cs
@@ -231,6 +231,46 @@ public class TagTests
         result.Value.Should().Be(2.3f);
     }
 
+    [Test]
+    public Task Duplicate_ValidConfig_ShouldBeVerified()
+    {
+        var content = L5X.Load(Known.Test);
+        var tag = content.Get<Tag>(Known.Tag);
+
+        var duplicate = tag.Duplicate(t =>
+        {
+            t.Name = "NewSimpleTag";
+            t.Description = "This is an updated tag";
+            t["DintMember"].Value = 56203;
+            t["RealMember"].Value = 345.6f;
+        });
+
+        return Verify(duplicate.Serialize().ToString());
+    }
+
+    [Test]
+    public void Replace_NameProperty_ShouldBeVerified()
+    {
+        var tag = Tag.Create<BOOL>("MyBoolTag");
+
+        tag.Replace("My", "Test", t => t.Name);
+
+        tag.Name.Should().StartWith("Test");
+    }
+
+    [Test]
+    public void Replace_DescriptionProperty_ShouldBeExpected()
+    {
+        var tag = Tag.Configure("SomeTimer")
+            .AsStructure("TIMER")
+            .WithDescription("This is a test tag")
+            .Build();
+
+        tag.Replace("test", "timer", t => t.Description);
+
+        tag.Description.Should().Contain("timer");
+    }
+
     #endregion
 
     #region DeserializeTests

--- a/tests/L5Sharp.Tests.Core/L5Sharp.Tests.Core.csproj
+++ b/tests/L5Sharp.Tests.Core/L5Sharp.Tests.Core.csproj
@@ -375,6 +375,12 @@
       <None Update="Components\TagTests.Build_SimpleAliasTag_ShouldBeVerified.verified.txt">
         <DependentUpon>TagTests.cs</DependentUpon>
       </None>
+      <None Update="Components\TagTests.Duplicate_ValidConfig_ShouldBeVerified.verified.txt">
+        <DependentUpon>TagTests.cs</DependentUpon>
+      </None>
+      <None Update="Components\ProgramTests.Duplicate_ValidConfig_ShouldBeVerified.verified.txt">
+        <DependentUpon>ProgramTests.cs</DependentUpon>
+      </None>
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/L5Sharp.Tests.Core/LogixElementTests.cs
+++ b/tests/L5Sharp.Tests.Core/LogixElementTests.cs
@@ -1083,7 +1083,7 @@ public class TestElement : LogixObject<TestElement>
     public string? Description
     {
         get => GetProperty<string>();
-        set => SetDescription(value);
+        set => SetProperty(value);
     }
 
     public DateTime? Date


### PR DESCRIPTION
Introduced a Duplicate method for cloning and configuring components, and a Replace method to handle string replacements in XML elements. Updated core utilities for FindAndReplace functionality and fixed minor documentation errors. Additionally, bumped the library version to 5.3.0 to reflect these changes.